### PR TITLE
refactor: ViewModelからRepositoryへの直接参照を解消

### DIFF
--- a/app/src/main/java/com/zelretch/aniiiiiict/MainViewModel.kt
+++ b/app/src/main/java/com/zelretch/aniiiiiict/MainViewModel.kt
@@ -3,7 +3,7 @@ package com.zelretch.aniiiiiict
 import android.content.Context
 import androidx.core.net.toUri
 import androidx.lifecycle.viewModelScope
-import com.zelretch.aniiiiiict.data.repository.AnnictRepository
+import com.zelretch.aniiiiiict.domain.usecase.AnnictAuthUseCase
 import com.zelretch.aniiiiiict.ui.base.BaseUiState
 import com.zelretch.aniiiiiict.ui.base.BaseViewModel
 import com.zelretch.aniiiiiict.ui.base.CustomTabsIntentFactory
@@ -28,7 +28,7 @@ data class MainUiState(
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
-    private val repository: AnnictRepository,
+    private val annictAuthUseCase: AnnictAuthUseCase,
     private val customTabsIntentFactory: CustomTabsIntentFactory,
     logger: Logger,
     @ApplicationContext private val context: Context
@@ -57,7 +57,7 @@ class MainViewModel @Inject constructor(
     private fun checkAuthState() {
         viewModelScope.launch {
             try {
-                val isAuthenticated = repository.isAuthenticated()
+                val isAuthenticated = annictAuthUseCase.isAuthenticated()
 
                 // UI状態を更新
                 _uiState.update { it.copy(isAuthenticated = isAuthenticated) }
@@ -89,7 +89,7 @@ class MainViewModel @Inject constructor(
 
         viewModelScope.launch {
             try {
-                val authUrl = repository.getAuthUrl()
+                val authUrl = annictAuthUseCase.getAuthUrl()
                 logger.info(TAG, "認証URLを取得: $authUrl", "startAuth")
 
                 delay(200)
@@ -122,7 +122,7 @@ class MainViewModel @Inject constructor(
 
                     if (!isActive) return@launch
 
-                    val success = repository.handleAuthCallback(code)
+                    val success = annictAuthUseCase.handleAuthCallback(code)
                     if (success) {
                         println("MainViewModel: 認証成功")
                         delay(300)

--- a/app/src/main/java/com/zelretch/aniiiiiict/domain/usecase/AnnictAuthUseCase.kt
+++ b/app/src/main/java/com/zelretch/aniiiiiict/domain/usecase/AnnictAuthUseCase.kt
@@ -1,0 +1,26 @@
+package com.zelretch.aniiiiiict.domain.usecase
+
+import com.zelretch.aniiiiiict.data.repository.AnnictRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AnnictAuthUseCase @Inject constructor(
+    private val repository: AnnictRepository
+) {
+    suspend fun isAuthenticated(): Boolean {
+        return repository.isAuthenticated()
+    }
+
+    suspend fun getAuthUrl(): String {
+        return repository.getAuthUrl()
+    }
+
+    suspend fun handleAuthCallback(code: String?): Boolean {
+        return if (code != null) {
+            repository.handleAuthCallback(code)
+        } else {
+            false
+        }
+    }
+}

--- a/app/src/main/java/com/zelretch/aniiiiiict/domain/usecase/JudgeFinaleUseCase.kt
+++ b/app/src/main/java/com/zelretch/aniiiiiict/domain/usecase/JudgeFinaleUseCase.kt
@@ -1,10 +1,7 @@
 package com.zelretch.aniiiiiict.domain.usecase
 
-import com.zelretch.aniiiiiict.data.model.AniListMedia
+import com.zelretch.aniiiiiict.data.repository.AniListRepository
 import com.zelretch.aniiiiiict.util.Logger
-import java.time.Instant
-import java.time.ZoneId
-import java.time.ZonedDateTime
 import javax.inject.Inject
 
 enum class FinaleState {
@@ -20,52 +17,79 @@ data class JudgeFinaleResult(
 )
 
 class JudgeFinaleUseCase @Inject constructor(
-    private val logger: Logger
+    private val logger: Logger,
+    private val aniListRepository: AniListRepository
 ) {
 
     private val TAG = "JudgeFinaleUseCase"
 
-    operator fun invoke(currentEpisodeNumber: Int, media: AniListMedia): JudgeFinaleResult {
-        logger.info(TAG, "最終話判定を開始: currentEpisode=$currentEpisodeNumber, mediaId=${media.id}", "JudgeFinaleUseCase.invoke")
+    suspend operator fun invoke(currentEpisodeNumber: Int, mediaId: Int): JudgeFinaleResult {
+        logger.info(
+            TAG,
+            "最終話判定を開始: currentEpisode=$currentEpisodeNumber, mediaId=$mediaId",
+            "JudgeFinaleUseCase.invoke"
+        )
 
-        // format != TV の場合、最終話判定ロジックをスキップ
-        if (media.format != null && media.format != "TV") {
-            logger.info(TAG, "フォーマットがTVではないため判定をスキップ: format=${media.format}", "JudgeFinaleUseCase.invoke")
-            return JudgeFinaleResult(FinaleState.UNKNOWN, false)
-        }
+        val result = aniListRepository.getMedia(mediaId)
 
-        // 1. 次回予定ありかつ nextAiringEpisode.episode > currentEp → not_finale
-        media.nextAiringEpisode?.let { nextAiring ->
-            if (nextAiring.episode > currentEpisodeNumber) {
-                logger.info(TAG, "次回エピソードが現在のエピソードより大きいためNOT_FINALE", "JudgeFinaleUseCase.invoke")
-                return JudgeFinaleResult(FinaleState.NOT_FINALE, false)
+        return result.fold(
+            onSuccess = { media ->
+                // format != TV の場合、最終話判定ロジックをスキップ
+                if (media.format != null && media.format != "TV") {
+                    logger.info(
+                        TAG,
+                        "フォーマットがTVではないため判定をスキップ: format=${media.format}",
+                        "JudgeFinaleUseCase.invoke"
+                    )
+                    return JudgeFinaleResult(FinaleState.UNKNOWN, false)
+                }
+
+                // 1. 次回予定ありかつ nextAiringEpisode.episode > currentEp → not_finale
+                media.nextAiringEpisode?.let { nextAiring ->
+                    if (nextAiring.episode > currentEpisodeNumber) {
+                        logger.info(
+                            TAG,
+                            "次回エピソードが現在のエピソードより大きいためNOT_FINALE",
+                            "JudgeFinaleUseCase.invoke"
+                        )
+                        return JudgeFinaleResult(FinaleState.NOT_FINALE, false)
+                    }
+                }
+
+                // 2. episodes が数値 かつ currentEp >= episodes かつ nextAiringEpisode == null → finale_confirmed
+                if (media.episodes != null && currentEpisodeNumber >= media.episodes && media.nextAiringEpisode == null) {
+                    logger.info(
+                        TAG,
+                        "総エピソード数と一致し、次回エピソードがないためFINALE_CONFIRMED",
+                        "JudgeFinaleUseCase.invoke"
+                    )
+                    return JudgeFinaleResult(FinaleState.FINALE_CONFIRMED, true)
+                }
+
+                // 3. status == FINISHED かつ nextAiringEpisode == null → finale_confirmed
+                if (media.status == "FINISHED" && media.nextAiringEpisode == null) {
+                    logger.info(
+                        TAG,
+                        "ステータスがFINISHEDで、次回エピソードがないためFINALE_CONFIRMED",
+                        "JudgeFinaleUseCase.invoke"
+                    )
+                    return JudgeFinaleResult(FinaleState.FINALE_CONFIRMED, true)
+                }
+
+                // 4. nextAiringEpisode == null（ただし 2,3 未満足） → finale_expected
+                if (media.nextAiringEpisode == null) {
+                    logger.info(TAG, "次回エピソードがないためFINALE_EXPECTED", "JudgeFinaleUseCase.invoke")
+                    return JudgeFinaleResult(FinaleState.FINALE_EXPECTED, false)
+                }
+
+                // 5. それ以外 → unknown
+                logger.info(TAG, "判定条件に合致しないためUNKNOWN", "JudgeFinaleUseCase.invoke")
+                JudgeFinaleResult(FinaleState.UNKNOWN, false)
+            },
+            onFailure = { e ->
+                logger.error(TAG, e, "AniListからの作品情報取得に失敗しました")
+                JudgeFinaleResult(FinaleState.UNKNOWN, false) // エラー時は不明として扱う
             }
-        }
-
-        // 2. episodes が数値 かつ currentEp >= episodes かつ nextAiringEpisode == null → finale_confirmed
-        if (media.episodes != null && currentEpisodeNumber >= media.episodes && media.nextAiringEpisode == null) {
-            logger.info(TAG, "総エピソード数と一致し、次回エピソードがないためFINALE_CONFIRMED", "JudgeFinaleUseCase.invoke")
-            return JudgeFinaleResult(FinaleState.FINALE_CONFIRMED, true)
-        }
-
-        // 3. status == FINISHED かつ nextAiringEpisode == null → finale_confirmed
-        if (media.status == "FINISHED" && media.nextAiringEpisode == null) {
-            logger.info(TAG, "ステータスがFINISHEDで、次回エピソードがないためFINALE_CONFIRMED", "JudgeFinaleUseCase.invoke")
-            return JudgeFinaleResult(FinaleState.FINALE_CONFIRMED, true)
-        }
-
-        // 4. nextAiringEpisode == null（ただし 2,3 未満足） → finale_expected
-        if (media.nextAiringEpisode == null) {
-            logger.info(TAG, "次回エピソードがないためFINALE_EXPECTED", "JudgeFinaleUseCase.invoke")
-            return JudgeFinaleResult(FinaleState.FINALE_EXPECTED, false)
-        }
-
-        // 5. それ以外 → unknown
-        logger.info(TAG, "判定条件に合致しないためUNKNOWN", "JudgeFinaleUseCase.invoke")
-        return JudgeFinaleResult(FinaleState.UNKNOWN, false)
-    }
-
-    fun convertUnixTimestampToJST(unixTimestamp: Int): ZonedDateTime {
-        return ZonedDateTime.ofInstant(Instant.ofEpochSecond(unixTimestamp.toLong()), ZoneId.of("Asia/Tokyo"))
+        )
     }
 }

--- a/app/src/main/java/com/zelretch/aniiiiiict/ui/track/TrackViewModel.kt
+++ b/app/src/main/java/com/zelretch/aniiiiiict/ui/track/TrackViewModel.kt
@@ -54,7 +54,6 @@ class TrackViewModel @Inject constructor(
     private val watchEpisodeUseCase: WatchEpisodeUseCase,
     private val filterProgramsUseCase: FilterProgramsUseCase,
     private val filterPreferences: FilterPreferences,
-    private val aniListRepository: AniListRepository,
     private val judgeFinaleUseCase: JudgeFinaleUseCase,
     logger: Logger,
     @ApplicationContext private val context: Context
@@ -151,16 +150,12 @@ class TrackViewModel @Inject constructor(
                     val currentEpisode = program?.programs?.find { it.episode.id == episodeId }
 
                     if (program != null && currentEpisode != null && currentEpisode.episode.number != null) {
-                        aniListRepository.getMedia(program.work.id.toInt()).onSuccess { anilistMedia ->
-                            val judgeResult = judgeFinaleUseCase(currentEpisode.episode.number!!, anilistMedia)
-                            if (judgeResult.isFinale) {
-                                _uiState.update { it.copy(
-                                    showFinaleConfirmationForWorkId = workId,
-                                    showFinaleConfirmationForEpisodeNumber = currentEpisode.episode.number
-                                )}
-                            }
-                        }.onFailure { e ->
-                            logger.error(TAG, e, "AniListからの作品情報取得に失敗しました")
+                        val judgeResult = judgeFinaleUseCase(currentEpisode.episode.number, program.work.id.toInt())
+                        if (judgeResult.isFinale) {
+                            _uiState.update { it.copy(
+                                showFinaleConfirmationForWorkId = workId,
+                                showFinaleConfirmationForEpisodeNumber = currentEpisode.episode.number
+                            )}
                         }
                     }
                 }.onFailure { e ->

--- a/app/src/test/java/com/zelretch/aniiiiiict/domain/usecase/JudgeFinaleUseCaseTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiiict/domain/usecase/JudgeFinaleUseCaseTest.kt
@@ -5,11 +5,15 @@ import com.zelretch.aniiiiiict.data.model.NextAiringEpisode
 import com.zelretch.aniiiiiict.util.TestLogger
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import io.mockk.coEvery
+import com.zelretch.aniiiiiict.data.repository.AniListRepository
 
 class JudgeFinaleUseCaseTest : BehaviorSpec({
 
     val logger = TestLogger()
-    val judgeFinaleUseCase = JudgeFinaleUseCase(logger)
+    val aniListRepository = mockk<AniListRepository>()
+    val judgeFinaleUseCase = JudgeFinaleUseCase(logger, aniListRepository)
 
     given("最終話判定ロジック") {
         `when`("次回予定ありかつ nextAiringEpisode.episode > currentEp の場合") {
@@ -21,7 +25,8 @@ class JudgeFinaleUseCaseTest : BehaviorSpec({
                     status = "RELEASING",
                     nextAiringEpisode = NextAiringEpisode(episode = 11, airingAt = 1678886400) // 次回が現在のエピソードより大きい
                 )
-                val result = judgeFinaleUseCase(10, media)
+                coEvery { aniListRepository.getMedia(media.id) } returns Result.success(media)
+                val result = judgeFinaleUseCase(10, media.id)
                 result.state shouldBe FinaleState.NOT_FINALE
                 result.isFinale shouldBe false
             }
@@ -36,7 +41,8 @@ class JudgeFinaleUseCaseTest : BehaviorSpec({
                     status = "RELEASING",
                     nextAiringEpisode = null
                 )
-                val result = judgeFinaleUseCase(12, media)
+                coEvery { aniListRepository.getMedia(media.id) } returns Result.success(media)
+                val result = judgeFinaleUseCase(12, media.id)
                 result.state shouldBe FinaleState.FINALE_CONFIRMED
                 result.isFinale shouldBe true
             }
@@ -51,7 +57,8 @@ class JudgeFinaleUseCaseTest : BehaviorSpec({
                     status = "FINISHED",
                     nextAiringEpisode = null
                 )
-                val result = judgeFinaleUseCase(10, media)
+                coEvery { aniListRepository.getMedia(media.id) } returns Result.success(media)
+                val result = judgeFinaleUseCase(10, media.id)
                 result.state shouldBe FinaleState.FINALE_CONFIRMED
                 result.isFinale shouldBe true
             }
@@ -66,7 +73,8 @@ class JudgeFinaleUseCaseTest : BehaviorSpec({
                     status = "RELEASING",
                     nextAiringEpisode = null
                 )
-                val result = judgeFinaleUseCase(10, media)
+                coEvery { aniListRepository.getMedia(media.id) } returns Result.success(media)
+                val result = judgeFinaleUseCase(10, media.id)
                 result.state shouldBe FinaleState.FINALE_EXPECTED
                 result.isFinale shouldBe false
             }
@@ -81,7 +89,8 @@ class JudgeFinaleUseCaseTest : BehaviorSpec({
                     status = "RELEASING",
                     nextAiringEpisode = NextAiringEpisode(episode = 10, airingAt = 1678886400) // 次回が現在のエピソード以下
                 )
-                val result = judgeFinaleUseCase(10, media)
+                coEvery { aniListRepository.getMedia(media.id) } returns Result.success(media)
+                val result = judgeFinaleUseCase(10, media.id)
                 result.state shouldBe FinaleState.UNKNOWN
                 result.isFinale shouldBe false
             }
@@ -96,7 +105,8 @@ class JudgeFinaleUseCaseTest : BehaviorSpec({
                     status = "FINISHED",
                     nextAiringEpisode = null
                 )
-                val result = judgeFinaleUseCase(1, media)
+                coEvery { aniListRepository.getMedia(media.id) } returns Result.success(media)
+                val result = judgeFinaleUseCase(1, media.id)
                 result.state shouldBe FinaleState.UNKNOWN
                 result.isFinale shouldBe false
             }

--- a/app/src/test/java/com/zelretch/aniiiiiict/ui/track/TrackViewModelTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiiict/ui/track/TrackViewModelTest.kt
@@ -32,7 +32,6 @@ class TrackViewModelTest : BehaviorSpec({
     val watchEpisodeUseCase = mockk<WatchEpisodeUseCase>()
     mockk<BulkRecordEpisodesUseCase>()
     val filterProgramsUseCase = mockk<FilterProgramsUseCase>()
-    val anilistRepository = mockk<AniListRepository>()
     val judgeFinalUseCase = mockk<JudgeFinaleUseCase>()
     val logger = mockk<Logger>(relaxed = true)
     val context = mockk<Context>(relaxed = true)
@@ -56,7 +55,6 @@ class TrackViewModelTest : BehaviorSpec({
             watchEpisodeUseCase,
             filterProgramsUseCase,
             filterPreferences,
-            anilistRepository,
             judgeFinalUseCase,
             logger,
             context


### PR DESCRIPTION
クリーンアーキテクチャの原則に基づき、ViewModelからRepositoryへの直接参照を解消しました。

- MainViewModel: AnnictRepositoryへの参照をAnnictAuthUseCaseを介するように変更。
- TrackViewModel: AniListRepositoryへの参照をJudgeFinaleUseCase内に統合。

これにより、ViewModelの責務がUIの状態管理とユーザーインタラクションに集中し、ドメインロジックの凝集度とテスト容易性が向上しました。関連するテストも修正し、すべてのテストが正常にパスすることを確認済みです。