### PR TITLE
feat: Gradle設定ファイルを整理

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,3 @@
-import java.util.*
-
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -7,14 +5,10 @@ plugins {
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.apollo)
+    alias(libs.plugins.secrets.gradle.plugin)
 }
 
-val localProperties = Properties().apply {
-    val localPropertiesFile = project.rootProject.file("local.properties")
-    if (localPropertiesFile.exists()) {
-        load(localPropertiesFile.inputStream())
-    }
-}
+
 
 android {
     namespace = "com.zelretch.aniiiiiict"
@@ -38,12 +32,7 @@ android {
             "ANNICT_CLIENT_ID",
             "\"9TBFInCwtgcRuVcK-F892iXt8vQmSci6rbAYg3eNHgk\""
         )
-        // CLIENT_SECRETはlocal.propertiesから読み込み
-        buildConfigField(
-            "String",
-            "ANNICT_CLIENT_SECRET",
-            "\"${localProperties.getProperty("ANNICT_CLIENT_SECRET", "")}\""
-        )
+
         buildConfigField(
             "String",
             "ANILIST_API_URL",
@@ -103,11 +92,13 @@ tasks.withType<Test> {
 }
 
 dependencies {
-    // Android Core
+    // AndroidX
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.browser)
+    implementation(libs.androidx.datastore.preferences)
+    implementation(libs.navigation.compose)
 
     // Compose
     implementation(platform(libs.compose.bom))
@@ -116,33 +107,25 @@ dependencies {
     implementation(libs.compose.material.icons)
     implementation(libs.compose.material)
 
-    // Hilt
+    // DI (Hilt)
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
     implementation(libs.hilt.navigation.compose)
 
-    // Retrofit & OkHttp
+    // Network
     implementation(libs.bundles.retrofit)
     implementation(libs.bundles.okhttp)
+    implementation(libs.bundles.apollo)
 
-    // Coroutines
+    // Async
     implementation(libs.coroutines.android)
-    testImplementation(libs.coroutines.test)
 
-    // Coil
+    // UI
     implementation(libs.coil)
     implementation(libs.coil.compose)
 
-    // Navigation
-    implementation(libs.navigation.compose)
-
-    // Apollo Client
-    implementation(libs.bundles.apollo)
-
-    // DataStore
-    implementation(libs.androidx.datastore.preferences)
-
     // Testing
+    testImplementation(libs.coroutines.test)
     testImplementation(libs.bundles.testing)
     androidTestImplementation(platform(libs.compose.bom))
     androidTestImplementation(libs.bundles.android.testing)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,12 +8,3 @@ plugins {
     alias(libs.plugins.apollo) apply false
 }
 
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath(libs.hilt.android.gradle.plugin)
-    }
-}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,46 +1,41 @@
 [versions]
 # Plugins
 agp = "8.10.1"
-datastore-preferences = "1.1.6"
 kotlin = "2.0.0"
-kotlin-compose = "2.1.20"
-ksp = "2.1.20-1.0.32"
+kotlin-compose = "2.0.0"
+ksp = "2.0.0-1.0.21"
 hilt = "2.56"
 apollo = "4.2.0"
-kotest = "5.8.1"
-mockk = "1.13.10"
+secrets-gradle-plugin = "2.0.1"
 
-# Core
+# AndroidX
 core-ktx = "1.16.0"
 lifecycle = "2.9.0"
 activity-compose = "1.10.1"
 browser = "1.8.0"
+datastore-preferences = "1.1.6"
+navigation-compose = "2.9.0"
 
 # Compose
 compose-bom = "2025.05.00"
 compose-material3 = "1.3.2"
 compose-material = "1.8.1"
 
-# Hilt
-hilt-android = "2.50"  # app/build.gradleでは2.50を使用
+# DI
 hilt-navigation = "1.2.0"
 
 # Network
 retrofit = "2.11.0"
 okhttp = "4.12.0"
-okhttp-logging = "4.11.0"
 gson = "2.11.0"
 
 # Async
 coroutines = "1.9.0"
 
-# Image
+# UI
 coil = "2.5.0"
 
-# Navigation
-navigation-compose = "2.9.0"
-
-# Test - 必要に応じて追加
+# Testing
 junit = "4.13.2"
 mockito-core = "5.10.0"
 mockito-kotlin = "5.2.1"
@@ -50,14 +45,17 @@ robolectric = "4.10.3"
 androidx-test-core = "1.6.1"
 androidx-test-junit = "1.2.1"
 turbine = "1.0.0"
+kotest = "5.8.1"
+mockk = "1.13.10"
 
 [libraries]
-# Android Core
+# AndroidX
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore-preferences" }
 androidx-lifecycle-runtime = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
 androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "browser" }
+navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation-compose" }
 
 # Compose
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
@@ -70,36 +68,29 @@ compose-material3 = { group = "androidx.compose.material3", name = "material3", 
 compose-material-icons = { group = "androidx.compose.material", name = "material-icons-extended" }
 compose-material = { group = "androidx.compose.material", name = "material", version.ref = "compose-material" }
 
-# Hilt
-hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt-android" }
-hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt-android" }
+# DI (Hilt)
+hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
+hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hilt-navigation" }
 hilt-android-gradle-plugin = { group = "com.google.dagger", name = "hilt-android-gradle-plugin", version.ref = "hilt" }
 
-# Retrofit
+# Network
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 retrofit-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
-
-# OkHttp
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
-okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp-logging" }
-
-# Coroutines
-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
-
-# Coil
-coil = { group = "io.coil-kt", name = "coil", version.ref = "coil" }
-coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
-
-# Navigation
-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation-compose" }
-
-# Apollo
+okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 apollo-runtime = { group = "com.apollographql.apollo", name = "apollo-runtime", version.ref = "apollo" }
 apollo-normalized-cache = { group = "com.apollographql.apollo", name = "apollo-normalized-cache", version.ref = "apollo" }
 apollo-adapters = { group = "com.apollographql.apollo", name = "apollo-adapters", version.ref = "apollo" }
+
+# Async
+coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
+coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
+
+# UI
+coil = { group = "io.coil-kt", name = "coil", version.ref = "coil" }
+coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 
 # Testing
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -114,13 +105,10 @@ kotest-runner-junit5 = { group = "io.kotest", name = "kotest-runner-junit5", ver
 kotest-assertions-core = { group = "io.kotest", name = "kotest-assertions-core", version.ref = "kotest" }
 kotest-framework = { group = "io.kotest", name = "kotest-framework-datatest", version.ref = "kotest" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
-
-# Robolectric
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
-
-# AndroidX Test
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidx-test-core" }
 androidx-test-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-junit" }
+
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -130,6 +118,7 @@ kotlin-plugin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.re
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 apollo = { id = "com.apollographql.apollo", version.ref = "apollo" }
+secrets-gradle-plugin = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "secrets-gradle-plugin" }
 
 [bundles]
 compose-ui = ["compose-ui", "compose-ui-graphics", "compose-ui-tooling-preview"]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,10 +5,6 @@ pluginManagement {
         gradlePluginPortal()
         maven { url = uri("https://maven.pkg.jetbrains.space/public/p/compose/dev") }
         maven { url = uri("https://www.jitpack.io") }
-        
-        // KSP用のリポジトリを追加
-        maven { url = uri("https://androidx.dev/snapshots/builds") }
-        maven { url = uri("https://dl.bintray.com/kotlin/kotlin-eap") }
     }
 }
 @Suppress("UnstableApiUsage")
@@ -19,12 +15,8 @@ dependencyResolutionManagement {
         mavenCentral()
         maven { url = uri("https://maven.pkg.jetbrains.space/public/p/compose/dev") }
         maven { url = uri("https://www.jitpack.io") }
-        
-        // KSP用のリポジトリを追加
-        maven { url = uri("https://androidx.dev/snapshots/builds") }
-        maven { url = uri("https://dl.bintray.com/kotlin/kotlin-eap") }
     }
 }
 
 rootProject.name = "Aniiiiiict"
-include(":app") 
+include(":app")


### PR DESCRIPTION
- プロジェクトルートのbuild.gradle.ktsから不要なbuildscriptブロックを削除
- libs.versions.tomlの各種ライブラリのバージョンを統一
- libs.versions.tomlのライブラリをカテゴリに再分類
- app/build.gradle.ktsのdependenciesブロックをカテゴリに合わせて整理
- settings.gradle.ktsから不要なリポジトリを削除
- Secrets Gradle Pluginを導入し、APIキーの管理方法を改善

Closes #26