### PR TITLE
test: ViewModel/UseCaseの単体テストカバレッジを向上

### DIFF
--- a/app/src/main/java/com/zelretch/aniiiiiict/ui/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/zelretch/aniiiiiict/ui/history/HistoryViewModel.kt
@@ -91,7 +91,6 @@ class HistoryViewModel @Inject constructor(
         }
     }
 
-    // TODO: この部分がドメインと分離できてない
     fun deleteRecord(recordId: String) {
         executeWithLoading {
             deleteRecordUseCase(recordId)
@@ -99,17 +98,9 @@ class HistoryViewModel @Inject constructor(
                 val newAllRecords = currentState.allRecords.filter { it.id != recordId }
                 currentState.copy(
                     allRecords = newAllRecords,
-                    records = filterRecords(newAllRecords, currentState.searchQuery)
+                    records = searchRecordsUseCase(newAllRecords, currentState.searchQuery)
                 )
             }
-        }
-    }
-
-    // TODO: こっちも
-    private fun filterRecords(records: List<Record>, query: String): List<Record> {
-        if (query.isEmpty()) return records
-        return records.filter { record ->
-            record.work.title.contains(query, ignoreCase = true)
         }
     }
 } 

--- a/app/src/test/java/com/zelretch/aniiiiiict/domain/usecase/AnnictAuthUseCaseTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiiict/domain/usecase/AnnictAuthUseCaseTest.kt
@@ -1,0 +1,64 @@
+package com.zelretch.aniiiiiict.domain.usecase
+
+import com.zelretch.aniiiiiict.data.repository.AnnictRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.MockitoAnnotations
+
+class AnnictAuthUseCaseTest {
+
+    @Mock
+    private lateinit var repository: AnnictRepository
+
+    private lateinit var useCase: AnnictAuthUseCase
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        useCase = AnnictAuthUseCase(repository)
+    }
+
+    @Test
+    fun `isAuthenticated should return true when repository returns true`() = runTest {
+        `when`(repository.isAuthenticated()).thenReturn(true)
+        assertTrue(useCase.isAuthenticated())
+    }
+
+    @Test
+    fun `isAuthenticated should return false when repository returns false`() = runTest {
+        `when`(repository.isAuthenticated()).thenReturn(false)
+        assertFalse(useCase.isAuthenticated())
+    }
+
+    @Test
+    fun `getAuthUrl should return correct url`() = runTest {
+        val authUrl = "https://example.com/auth"
+        `when`(repository.getAuthUrl()).thenReturn(authUrl)
+        assertEquals(authUrl, useCase.getAuthUrl())
+    }
+
+    @Test
+    fun `handleAuthCallback should return true when code is valid`() = runTest {
+        val code = "valid_code"
+        `when`(repository.handleAuthCallback(code)).thenReturn(true)
+        assertTrue(useCase.handleAuthCallback(code))
+    }
+
+    @Test
+    fun `handleAuthCallback should return false when code is null`() = runTest {
+        assertFalse(useCase.handleAuthCallback(null))
+    }
+
+    @Test
+    fun `handleAuthCallback should return false when code is invalid`() = runTest {
+        val code = "invalid_code"
+        `when`(repository.handleAuthCallback(code)).thenReturn(false)
+        assertFalse(useCase.handleAuthCallback(code))
+    }
+}


### PR DESCRIPTION
- AnnictAuthUseCaseの単体テストを追加\n- HistoryViewModelのテストを拡充\n- HistoryViewModelのレコードフィルタリング処理をリファクタリング