### PR TITLE
build: Gradle Configuration Cacheを有効にしてビルド速度を改善

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,8 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
-kotlin.code.style=official 
+kotlin.code.style=official
+
+# Enable Gradle Configuration Cache for faster builds
+# https://docs.gradle.org/current/userguide/configuration_cache.html
+org.gradle.configuration-cache=true 


### PR DESCRIPTION
gradle.propertiesに`org.gradle.configuration-cache=true`を追加しました。