### PR TITLE
masterにマージされたときも、動くように

### DIFF
--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [ master ]
-    types: [ opened, synchronize, reopened, closed ]
+    types: [ opened, synchronize, closed ]
 
 jobs:
   build:

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -3,11 +3,9 @@ name: Test and Lint
 on:
   pull_request:
     branches: [ master ]
-    types: [ opened, synchronize, reopened, closed ]
 
 jobs:
   build_and_test:
-    if: github.event.action != 'closed' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     env:
       GRADLE_OPTS: -Dorg.gradle.configuration-cache=false


### PR DESCRIPTION
よくかんがえたらmasterにマージされたときに動いてほしいのはbuildだけ
- 一人で実装している
- 基本的にはbranchは最新masterで生成され、その後masterはそのbranchのPRがマージされるまで更新される予定がない
- なんかあってもマージ前にmasterの取り込みを行っている