### PR TITLE
fix: deprecated APIの使用を修正

### DIFF
--- a/app/src/main/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailScreen.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailScreen.kt
@@ -14,7 +14,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -388,7 +388,7 @@ private fun AnimeDetailTopAppBar(title: String, onNavigateBack: () -> Unit) {
         navigationIcon = {
             IconButton(onClick = onNavigateBack) {
                 Icon(
-                    imageVector = Icons.Default.ArrowBack,
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                     contentDescription = "戻る"
                 )
             }

--- a/app/src/main/java/com/zelretch/aniiiiict/ui/common/components/StatusDropdown.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/ui/common/components/StatusDropdown.kt
@@ -7,9 +7,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
-import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -56,7 +56,7 @@ fun StatusDropdown(
                         ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
                     }
                 },
-                modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable, true)
+                modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable, true)
             )
             ExposedDropdownMenu(
                 expanded = expanded && !isChanging,


### PR DESCRIPTION
## Summary
deprecated警告が出ていたAPIを最新の推奨APIに置き換えました。

## Changes
- `Icons.Default.ArrowBack` → `Icons.AutoMirrored.Filled.ArrowBack` (AnimeDetailScreen)
- `MenuAnchorType` → `ExposedDropdownMenuAnchorType` (StatusDropdown)

## Test plan
- [x] `./gradlew check` 成功
- [x] Unit tests: 11 tests passed
- [x] ktlint: passed
- [x] detekt: passed
- [x] コンパイル時のdeprecated警告が消えたことを確認

Fixes #179