### PR TITLE
fix: 1期・2期がある作品の最終話判定を修正

### DIFF
--- a/app/src/androidTest/java/com/zelretch/aniiiiict/ui/track/TrackScreenIntegrationTest.kt
+++ b/app/src/androidTest/java/com/zelretch/aniiiiict/ui/track/TrackScreenIntegrationTest.kt
@@ -315,6 +315,7 @@ class TrackScreenIntegrationTest {
         every { episodeNode.number } returns episode.number
         every { episodeNode.numberText } returns episode.numberText
         every { episodeNode.title } returns episode.title
+        every { episodeNode.nextEpisode } returns null // 最終話なのでnextEpisodeはnull
         val workNode = mockk<ViewerProgramsQuery.Work>()
         every { workNode.id } returns work.id
         every { workNode.title } returns work.title
@@ -422,6 +423,9 @@ class TrackScreenIntegrationTest {
         every { episodeNode.number } returns episode.number
         every { episodeNode.numberText } returns episode.numberText
         every { episodeNode.title } returns episode.title
+        val nextEpisodeNode = mockk<ViewerProgramsQuery.NextEpisode>()
+        every { nextEpisodeNode.number } returns 9
+        every { episodeNode.nextEpisode } returns nextEpisodeNode // 最終話ではないので次話あり
         val workNode = mockk<ViewerProgramsQuery.Work>()
         every { workNode.id } returns work.id
         every { workNode.title } returns work.title

--- a/app/src/main/graphql/com.annict/ViewerPrograms.graphql
+++ b/app/src/main/graphql/com.annict/ViewerPrograms.graphql
@@ -22,6 +22,9 @@ query ViewerPrograms {
           number
           numberText
           title
+          nextEpisode {
+            number
+          }
         }
         work {
           id

--- a/app/src/main/java/com/zelretch/aniiiiict/data/model/Episode.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/data/model/Episode.kt
@@ -5,7 +5,8 @@ data class Episode(
     val number: Int? = null,
     val numberText: String? = null,
     val title: String? = null,
-    val viewerDidTrack: Boolean? = null
+    val viewerDidTrack: Boolean? = null,
+    val hasNextEpisode: Boolean = false
 ) {
     val formattedNumber: String get() = numberText ?: "第${number}話"
 }

--- a/app/src/main/java/com/zelretch/aniiiiict/domain/usecase/BulkRecordEpisodesUseCase.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/domain/usecase/BulkRecordEpisodesUseCase.kt
@@ -17,6 +17,7 @@ class BulkRecordEpisodesUseCase @Inject constructor(
         currentStatus: StatusState,
         malAnimeId: Int? = null,
         lastEpisodeNumber: Int? = null,
+        lastEpisodeHasNext: Boolean? = null,
         onProgress: (Int) -> Unit = {}
     ): Result<BulkRecordResult> {
         return runCatching {
@@ -35,7 +36,7 @@ class BulkRecordEpisodesUseCase @Inject constructor(
 
             // 最後のエピソードでフィナーレ判定を実行
             val finaleResult = if (malAnimeId != null && lastEpisodeNumber != null) {
-                judgeFinaleUseCase(lastEpisodeNumber, malAnimeId)
+                judgeFinaleUseCase(lastEpisodeNumber, malAnimeId, lastEpisodeHasNext)
             } else {
                 null
             }

--- a/app/src/main/java/com/zelretch/aniiiiict/domain/usecase/LoadProgramsUseCase.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/domain/usecase/LoadProgramsUseCase.kt
@@ -49,7 +49,8 @@ class LoadProgramsUseCase @Inject constructor(private val repository: AnnictRepo
                 id = node.episode.id,
                 number = node.episode.number,
                 numberText = node.episode.numberText,
-                title = node.episode.title
+                title = node.episode.title,
+                hasNextEpisode = node.episode.nextEpisode != null
             )
 
             val workImage = node.work.image?.let { image ->

--- a/app/src/main/java/com/zelretch/aniiiiict/ui/track/BroadcastEpisodeModalViewModel.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/ui/track/BroadcastEpisodeModalViewModel.kt
@@ -198,11 +198,12 @@ class BroadcastEpisodeModalViewModel @Inject constructor(
             return
         }
 
+        val hasNextEpisode = currentEpisode.episode.hasNextEpisode
         Timber.d(
             "DetailModal: handleSingleEpisodeFinaleJudgement - calling judgeFinaleUseCase " +
-                "with episodeNumber=$episodeNumber, malAnimeId=$malAnimeId"
+                "with episodeNumber=$episodeNumber, malAnimeId=$malAnimeId, hasNextEpisode=$hasNextEpisode"
         )
-        val judgeResult = judgeFinaleUseCase(episodeNumber, malAnimeId)
+        val judgeResult = judgeFinaleUseCase(episodeNumber, malAnimeId, hasNextEpisode)
         Timber.d(
             "DetailModal: handleSingleEpisodeFinaleJudgement - " +
                 "judgeResult.isFinale=${judgeResult.isFinale}, judgeResult.state=${judgeResult.state}"
@@ -231,9 +232,11 @@ class BroadcastEpisodeModalViewModel @Inject constructor(
         val workId = _state.value.workId
         val currentState = _state.value
         val malAnimeId = currentState.malAnimeId?.toIntOrNull()
-        val lastEpisodeNumber = currentState.programs
+        val lastEpisode = currentState.programs
             .find { it.episode.id == episodeIds.lastOrNull() }
-            ?.episode?.number
+            ?.episode
+        val lastEpisodeNumber = lastEpisode?.number
+        val lastEpisodeHasNext = lastEpisode?.hasNextEpisode
 
         viewModelScope.launch {
             _state.update {
@@ -251,6 +254,7 @@ class BroadcastEpisodeModalViewModel @Inject constructor(
                     currentStatus = status,
                     malAnimeId = malAnimeId,
                     lastEpisodeNumber = lastEpisodeNumber,
+                    lastEpisodeHasNext = lastEpisodeHasNext,
                     onProgress = { progress ->
                         _state.update { it.copy(bulkRecordingProgress = progress) }
                     }

--- a/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/LoadProgramsUseCaseTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/LoadProgramsUseCaseTest.kt
@@ -188,7 +188,8 @@ object TestHelper {
         episodeNumberText: String = "#1",
         episodeTitle: String = "エピソードタイトル",
         workId: String = "work-id",
-        workTitle: String = "作品タイトル"
+        workTitle: String = "作品タイトル",
+        hasNextEpisode: Boolean = true
     ): ViewerProgramsQuery.Node {
         val node = mockk<ViewerProgramsQuery.Node>()
 
@@ -204,6 +205,16 @@ object TestHelper {
         every { episode.number } returns episodeNumber
         every { episode.numberText } returns episodeNumberText
         every { episode.title } returns episodeTitle
+
+        // nextEpisodeのモック設定
+        if (hasNextEpisode) {
+            val nextEpisode = mockk<ViewerProgramsQuery.NextEpisode>()
+            every { nextEpisode.number } returns (episodeNumber ?: 0) + 1
+            every { episode.nextEpisode } returns nextEpisode
+        } else {
+            every { episode.nextEpisode } returns null
+        }
+
         every { node.episode } returns episode
 
         val work = mockk<ViewerProgramsQuery.Work>()

--- a/app/src/test/java/com/zelretch/aniiiiict/ui/track/BroadcastEpisodeModalViewModelTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/ui/track/BroadcastEpisodeModalViewModelTest.kt
@@ -133,6 +133,7 @@ class BroadcastEpisodeModalViewModelTest {
                 every { id } returns "ep-12"
                 every { number } returns 12
                 every { title } returns "最終話"
+                every { hasNextEpisode } returns false
             }
             val program = mockk<Program> {
                 every { this@mockk.episode } returns episode
@@ -146,7 +147,7 @@ class BroadcastEpisodeModalViewModelTest {
 
             coEvery { watchEpisodeUseCase(any(), any(), any()) } returns Result.success(Unit)
             coEvery {
-                judgeFinaleUseCase(12, 123)
+                judgeFinaleUseCase(12, 123, false)
             } returns JudgeFinaleResult(FinaleState.FINALE_CONFIRMED)
 
             viewModel.initialize(programWithWork)
@@ -174,6 +175,7 @@ class BroadcastEpisodeModalViewModelTest {
                 every { id } returns "ep-10"
                 every { number } returns 10
                 every { title } returns "第10話"
+                every { hasNextEpisode } returns true
             }
             val program = mockk<Program> {
                 every { this@mockk.episode } returns episode
@@ -187,7 +189,7 @@ class BroadcastEpisodeModalViewModelTest {
 
             coEvery { watchEpisodeUseCase(any(), any(), any()) } returns Result.success(Unit)
             coEvery {
-                judgeFinaleUseCase(10, 123)
+                judgeFinaleUseCase(10, 123, true)
             } returns JudgeFinaleResult(FinaleState.NOT_FINALE)
 
             viewModel.initialize(programWithWork)


### PR DESCRIPTION
## Summary
1期・2期がある作品で、通算エピソード番号での誤判定を防ぐため、AnnictのnextEpisode情報とMyAnimeListの情報を複合的に判定するようにしました。

## Problem
**例: 怪獣8号 第2期**
- 第2期: エピソード13-23（通算番号）
- MyAnimeListの`numEpisodes`: 11（第2期のみ）
- エピソード22を記録時: `22 >= 11` → **最終話と誤判定**
- 実際: 第2期の10話目で、23話が最終話

## Solution
AnnictのnextEpisode情報とMyAnimeListの情報を複合判定：

**判定ロジック:**
1. `hasNextEpisode == true` → NOT_FINALE（次話あり = 確実に最終話ではない）
2. `hasNextEpisode == false` OR `currentEp >= numEpisodes` → FINALE_CONFIRMED
3. その他、従来のMyAnimeList判定を継続

## Changes
- **GraphQL**: `ViewerPrograms`クエリに`episode.nextEpisode`を追加
- **Episode**: `hasNextEpisode: Boolean`フィールドを追加
- **JudgeFinaleUseCase**: nextEpisode情報を受け取り、複合判定を実装
- **BulkRecordEpisodesUseCase**: `lastEpisodeHasNext`パラメータを追加
- **BroadcastEpisodeModalViewModel**: 最終エピソードの`hasNextEpisode`を取得して渡す
- **LoadProgramsUseCase**: GraphQLレスポンスから`hasNextEpisode`をマッピング
- **Tests**: nextEpisode関連のモック設定を追加

## Test Plan
- [x] Unit Tests: 197 tests, 100% successful
- [x] `./gradlew check` 成功
- [ ] `./gradlew connectedDebugAndroidTest` 実行予定

Fixes #181