### PR TITLE
build: 各種ライブラリを最新の安定版に更新

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -148,6 +148,7 @@ android {
             excludes += "/META-INF/NOTICE.md"
             excludes += "/META-INF/NOTICE"
             excludes += "/META-INF/*.md"
+            excludes += "/META-INF/versions/9/OSGI-INF/MANIFEST.MF"
         }
     }
     testOptions {
@@ -176,6 +177,9 @@ dependencies {
     // Compose
     // Align Kotlin libs to the plugin version
     implementation(platform(libs.compose.bom))
+    implementation(platform(libs.kotlin.bom))
+    implementation(platform(libs.okhttp.bom))
+    implementation(platform(libs.coroutines.bom))
     implementation(libs.bundles.compose.ui)
     implementation(libs.compose.material3)
     implementation(libs.compose.material.icons)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,10 +2,10 @@
 # Plugins
 # AGPのバージョンはローカルのIDEが8.11までしか対応していないので一旦stay
 agp = "8.11.0"
-kotlin = "2.1.21"
-kotlin-compose = "2.1.21"
-ksp = "2.1.21-2.0.1"
-hilt = "2.57.1"
+kotlin = "2.2.20"
+kotlin-compose = "2.2.20"
+ksp = "2.2.20-2.0.4"
+hilt = "2.57.2"
 apollo = "4.3.3"
 ktlint = "13.0.0"
 detekt = "1.23.8"
@@ -16,18 +16,18 @@ lifecycle = "2.9.4"
 activity-compose = "1.11.0"
 browser = "1.9.0"
 datastore-preferences = "1.1.7"
-navigation-compose = "2.9.4"
+navigation-compose = "2.9.5"
 
 # Compose
 compose-bom = "2025.09.00"
-compose-material3 = "1.4.0-rc01"
+compose-material3 = "1.4.0"
 
 # DI
 hilt-navigation = "1.3.0"
 
 # Network
 retrofit = "3.0.0"
-okhttp = "5.1.0"
+okhttp = "5.2.1"
 gson = "2.13.2"
 
 # Async
@@ -49,8 +49,8 @@ robolectric = "4.10.3"
 androidx-test-core = "1.6.1"
 androidx-test-junit = "1.2.1"
 turbine = "1.0.0"
-kotest = "5.8.1"
-mockk = "1.13.10"
+kotest = "6.0.3"
+mockk = "1.14.5"
 
 [libraries]
 # AndroidX
@@ -80,15 +80,17 @@ hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-com
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 retrofit-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
-okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
-okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
+okhttp-bom = { group = "com.squareup.okhttp3", name = "okhttp-bom", version.ref = "okhttp" }
+okhttp = { group = "com.squareup.okhttp3", name = "okhttp" }
+okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor" }
 apollo-runtime = { group = "com.apollographql.apollo", name = "apollo-runtime", version.ref = "apollo" }
 apollo-normalized-cache = { group = "com.apollographql.apollo", name = "apollo-normalized-cache", version.ref = "apollo" }
 apollo-adapters = { group = "com.apollographql.apollo", name = "apollo-adapters", version.ref = "apollo" }
 
 # Async
-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
+coroutines-bom = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-bom", version.ref = "coroutines" }
+coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android" }
+coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test" }
 
 # UI
 coil = { group = "io.coil-kt", name = "coil", version.ref = "coil" }
@@ -96,6 +98,9 @@ coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coi
 
 # Logging
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
+
+# Kotlin
+kotlin-bom = { group = "org.jetbrains.kotlin", name = "kotlin-bom", version.ref = "kotlin" }
 
 # Testing
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -108,7 +113,7 @@ compose-ui-test = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 kotest-runner-junit5 = { group = "io.kotest", name = "kotest-runner-junit5", version.ref = "kotest" }
 kotest-assertions-core = { group = "io.kotest", name = "kotest-assertions-core", version.ref = "kotest" }
-kotest-framework = { group = "io.kotest", name = "kotest-framework-datatest", version.ref = "kotest" }
+
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
@@ -134,5 +139,5 @@ compose-debug = ["compose-ui-tooling", "compose-ui-test-manifest"]
 retrofit = ["retrofit", "retrofit-gson", "gson"]
 okhttp = ["okhttp", "okhttp-logging"]
 apollo = ["apollo-runtime", "apollo-normalized-cache", "apollo-adapters"]
-testing = ["junit", "mockito-core", "mockito-kotlin", "androidx-arch-testing", "coroutines-test", "kotest-framework", "mockk"]
+testing = ["junit", "mockito-core", "mockito-kotlin", "androidx-arch-testing", "coroutines-test", "mockk"]
 android-testing = ["androidx-test-junit", "espresso-core", "compose-ui-test", "mockito-android"]


### PR DESCRIPTION
依存関係を更新し、プロジェクトのメンテナンス性を向上させます。

主な変更点:
- OkHttp, Coroutines, KotlinにBOMを導入し、バージョン管理を簡素化。
- 依存関係の更新に伴うビルドエラーとテストエラーを修正。

更新されたライブラリ:
- Kotlin: 2.1.21 -> 2.2.20
- KSP: 2.1.21-2.0.1 -> 2.2.20-2.0.4
- Hilt: 2.57.1 -> 2.57.2
- OkHttp: 5.1.0 -> 5.2.1
- Kotest: 5.8.1 -> 6.0.3
- Mockk: 1.13.10 -> 1.14.5
- Navigation Compose: 2.9.4 -> 2.9.5
- Compose Material3: 1.4.0-rc01 -> 1.4.0