### PR TITLE
feat: MyAnimeListエピソード数不明時の最終話判定改善

### DIFF
--- a/app/src/androidTest/java/com/zelretch/aniiiiict/ui/library/WatchingEpisodeModalIntegrationTest.kt
+++ b/app/src/androidTest/java/com/zelretch/aniiiiict/ui/library/WatchingEpisodeModalIntegrationTest.kt
@@ -12,6 +12,7 @@ import com.zelretch.aniiiiict.data.repository.AnnictRepository
 import com.zelretch.aniiiiict.data.repository.MyAnimeListRepository
 import com.zelretch.aniiiiict.di.AppModule
 import com.zelretch.aniiiiict.domain.filter.ProgramFilter
+import com.zelretch.aniiiiict.domain.usecase.JudgeFinaleUseCase
 import com.zelretch.aniiiiict.domain.usecase.UpdateViewStateUseCase
 import com.zelretch.aniiiiict.domain.usecase.WatchEpisodeUseCase
 import com.zelretch.aniiiiict.testing.HiltComposeTestRule
@@ -47,6 +48,9 @@ class WatchingEpisodeModalIntegrationTest {
     lateinit var updateViewStateUseCase: UpdateViewStateUseCase
 
     @Inject
+    lateinit var judgeFinaleUseCase: JudgeFinaleUseCase
+
+    @Inject
     lateinit var errorMapper: ErrorMapper
 
     @BindValue
@@ -77,7 +81,8 @@ class WatchingEpisodeModalIntegrationTest {
     @Test
     fun watchingEpisodeModal_視聴済みボタンクリック_Repository呼び出しをcoVerifyできる() {
         // Arrange
-        val viewModel = WatchingEpisodeModalViewModel(watchEpisodeUseCase, updateViewStateUseCase, errorMapper)
+        val viewModel =
+            WatchingEpisodeModalViewModel(watchEpisodeUseCase, updateViewStateUseCase, judgeFinaleUseCase, errorMapper)
 
         val work = Work(
             id = "work-integration",
@@ -114,7 +119,8 @@ class WatchingEpisodeModalIntegrationTest {
     @Test
     fun watchingEpisodeModal_ステータス変更_Repository呼び出しをcoVerifyできる() {
         // Arrange
-        val viewModel = WatchingEpisodeModalViewModel(watchEpisodeUseCase, updateViewStateUseCase, errorMapper)
+        val viewModel =
+            WatchingEpisodeModalViewModel(watchEpisodeUseCase, updateViewStateUseCase, judgeFinaleUseCase, errorMapper)
 
         val work = Work(
             id = "work-status",
@@ -153,7 +159,8 @@ class WatchingEpisodeModalIntegrationTest {
     @Test
     fun watchingEpisodeModal_エピソードなし_視聴済みボタンが表示されない() {
         // Arrange
-        val viewModel = WatchingEpisodeModalViewModel(watchEpisodeUseCase, updateViewStateUseCase, errorMapper)
+        val viewModel =
+            WatchingEpisodeModalViewModel(watchEpisodeUseCase, updateViewStateUseCase, judgeFinaleUseCase, errorMapper)
 
         val work = Work(
             id = "work-no-ep",
@@ -186,7 +193,8 @@ class WatchingEpisodeModalIntegrationTest {
     @Test
     fun watchingEpisodeModal_noEpisodesがtrue_エピソード記録UIが非表示でステータス変更のみ可能() {
         // Arrange
-        val viewModel = WatchingEpisodeModalViewModel(watchEpisodeUseCase, updateViewStateUseCase, errorMapper)
+        val viewModel =
+            WatchingEpisodeModalViewModel(watchEpisodeUseCase, updateViewStateUseCase, judgeFinaleUseCase, errorMapper)
 
         val work = Work(
             id = "work-no-episodes",

--- a/app/src/main/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailScreen.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailScreen.kt
@@ -175,12 +175,10 @@ private fun AnimeDetailHeader(animeDetailInfo: AnimeDetailInfo, modifier: Modifi
                 )
             }
 
-            animeDetailInfo.episodeCount?.let { episodeCount ->
-                Text(
-                    text = "全${episodeCount}話",
-                    style = MaterialTheme.typography.bodyMedium
-                )
-            }
+            Text(
+                text = animeDetailInfo.episodeCount?.let { "全${it}話" } ?: "全?話",
+                style = MaterialTheme.typography.bodyMedium
+            )
         }
     }
 }

--- a/app/src/main/java/com/zelretch/aniiiiict/ui/track/BroadcastEpisodeModalViewModel.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/ui/track/BroadcastEpisodeModalViewModel.kt
@@ -8,6 +8,7 @@ import com.zelretch.aniiiiict.data.model.ProgramWithWork
 import com.zelretch.aniiiiict.domain.usecase.BulkRecordEpisodesUseCase
 import com.zelretch.aniiiiict.domain.usecase.BulkRecordResult
 import com.zelretch.aniiiiict.domain.usecase.FinaleJudgmentInfo
+import com.zelretch.aniiiiict.domain.usecase.FinaleState
 import com.zelretch.aniiiiict.domain.usecase.JudgeFinaleUseCase
 import com.zelretch.aniiiiict.domain.usecase.UpdateViewStateUseCase
 import com.zelretch.aniiiiict.domain.usecase.WatchEpisodeUseCase
@@ -212,9 +213,10 @@ class BroadcastEpisodeModalViewModel @Inject constructor(
                 "judgeResult.isFinale=${judgeResult.isFinale}, judgeResult.state=${judgeResult.state}"
         )
 
-        if (judgeResult.isFinale) {
+        // FINALE_CONFIRMED または UNKNOWN の場合、ユーザーに確認を求める
+        if (judgeResult.isFinale || judgeResult.state == FinaleState.UNKNOWN) {
             Timber.d(
-                "DetailModal: handleSingleEpisodeFinaleJudgement - finale detected, updating state"
+                "DetailModal: handleSingleEpisodeFinaleJudgement - finale or unknown detected, showing confirmation"
             )
             _state.update {
                 it.copy(
@@ -279,7 +281,9 @@ class BroadcastEpisodeModalViewModel @Inject constructor(
             index <= (_state.value.selectedEpisodeIndex ?: return)
         }
 
-        val shouldShowFinaleConfirmation = result.finaleResult?.isFinale == true
+        // FINALE_CONFIRMED または UNKNOWN の場合、ユーザーに確認を求める
+        val shouldShowFinaleConfirmation = result.finaleResult?.isFinale == true ||
+            result.finaleResult?.state == FinaleState.UNKNOWN
 
         _state.update {
             it.copy(

--- a/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/JudgeFinaleUseCaseTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/JudgeFinaleUseCaseTest.kt
@@ -74,8 +74,8 @@ class JudgeFinaleUseCaseTest {
         }
 
         @Test
-        @DisplayName("currently_airing且つnumEpisodesがnullの場合はunknownを返す")
-        fun currently_airing且つnumEpisodesがnullの場合はunknownを返す() = runTest {
+        @DisplayName("currently_airing且つnumEpisodesがnullでhasNextEpisode=trueの場合はnot_finaleを返す")
+        fun currently_airing且つnumEpisodesがnullでhasNextEpisode_trueの場合はnot_finaleを返す() = runTest {
             // Given
             val media = MyAnimeListResponse(
                 id = 4,
@@ -88,7 +88,51 @@ class JudgeFinaleUseCaseTest {
             coEvery { myAnimeListRepository.getAnimeDetail(media.id) } returns Result.success(media)
 
             // When
-            val result = judgeFinaleUseCase(10, media.id)
+            val result = judgeFinaleUseCase(10, media.id, hasNextEpisode = true)
+
+            // Then
+            assertEquals(FinaleState.NOT_FINALE, result.state)
+            assertFalse(result.isFinale)
+        }
+
+        @Test
+        @DisplayName("currently_airing且つnumEpisodesがnullでhasNextEpisode=falseの場合はunknownを返す")
+        fun currently_airing且つnumEpisodesがnullでhasNextEpisode_falseの場合はunknownを返す() = runTest {
+            // Given
+            val media = MyAnimeListResponse(
+                id = 5,
+                mediaType = "tv",
+                numEpisodes = null,
+                status = "currently_airing",
+                broadcast = null,
+                mainPicture = null
+            )
+            coEvery { myAnimeListRepository.getAnimeDetail(media.id) } returns Result.success(media)
+
+            // When
+            val result = judgeFinaleUseCase(10, media.id, hasNextEpisode = false)
+
+            // Then
+            assertEquals(FinaleState.UNKNOWN, result.state)
+            assertFalse(result.isFinale)
+        }
+
+        @Test
+        @DisplayName("currently_airing且つnumEpisodesがnullでhasNextEpisodeがnullの場合はunknownを返す")
+        fun currently_airing且つnumEpisodesがnullでhasNextEpisodeがnullの場合はunknownを返す() = runTest {
+            // Given
+            val media = MyAnimeListResponse(
+                id = 6,
+                mediaType = "tv",
+                numEpisodes = null,
+                status = "currently_airing",
+                broadcast = null,
+                mainPicture = null
+            )
+            coEvery { myAnimeListRepository.getAnimeDetail(media.id) } returns Result.success(media)
+
+            // When
+            val result = judgeFinaleUseCase(10, media.id, hasNextEpisode = null)
 
             // Then
             assertEquals(FinaleState.UNKNOWN, result.state)
@@ -100,7 +144,7 @@ class JudgeFinaleUseCaseTest {
         fun otherwise() = runTest {
             // Given
             val media = MyAnimeListResponse(
-                id = 5,
+                id = 7,
                 mediaType = "tv",
                 numEpisodes = 12,
                 status = "not_yet_aired",

--- a/app/src/test/java/com/zelretch/aniiiiict/ui/library/WatchingEpisodeModalViewModelTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/ui/library/WatchingEpisodeModalViewModelTest.kt
@@ -6,6 +6,7 @@ import com.zelretch.aniiiiict.data.model.Episode
 import com.zelretch.aniiiiict.data.model.LibraryEntry
 import com.zelretch.aniiiiict.data.model.Work
 import com.zelretch.aniiiiict.domain.error.DomainError
+import com.zelretch.aniiiiict.domain.usecase.JudgeFinaleUseCase
 import com.zelretch.aniiiiict.domain.usecase.UpdateViewStateUseCase
 import com.zelretch.aniiiiict.domain.usecase.WatchEpisodeUseCase
 import com.zelretch.aniiiiict.ui.base.ErrorMapper
@@ -43,12 +44,14 @@ class WatchingEpisodeModalViewModelTest {
         Dispatchers.setMain(dispatcher)
         watchEpisodeUseCase = mockk()
         updateViewStateUseCase = mockk()
+        val judgeFinaleUseCase = mockk<JudgeFinaleUseCase>(relaxed = true)
         errorMapper = mockk {
             every { toUserMessage(any(), any()) } returns "エラーが発生しました"
         }
         viewModel = WatchingEpisodeModalViewModel(
             watchEpisodeUseCase,
             updateViewStateUseCase,
+            judgeFinaleUseCase,
             errorMapper
         )
     }
@@ -75,6 +78,7 @@ class WatchingEpisodeModalViewModelTest {
                 every { title } returns "テスト作品"
                 every { viewerStatusState } returns StatusState.WATCHING
                 every { noEpisodes } returns false
+                every { malAnimeId } returns null
             }
             val entry = mockk<LibraryEntry> {
                 every { nextEpisode } returns episode
@@ -104,6 +108,7 @@ class WatchingEpisodeModalViewModelTest {
                 every { title } returns "テスト作品"
                 every { viewerStatusState } returns StatusState.WATCHING
                 every { noEpisodes } returns false
+                every { malAnimeId } returns null
             }
             val entry = mockk<LibraryEntry> {
                 every { nextEpisode } returns null
@@ -130,6 +135,7 @@ class WatchingEpisodeModalViewModelTest {
                 every { title } returns "エピソード情報なし作品"
                 every { viewerStatusState } returns StatusState.WATCHING
                 every { noEpisodes } returns true
+                every { malAnimeId } returns null
             }
             val entry = mockk<LibraryEntry> {
                 every { nextEpisode } returns null
@@ -162,6 +168,7 @@ class WatchingEpisodeModalViewModelTest {
                 every { title } returns "テスト作品"
                 every { viewerStatusState } returns StatusState.WATCHING
                 every { noEpisodes } returns false
+                every { malAnimeId } returns null
             }
             val entry = mockk<LibraryEntry> {
                 every { nextEpisode } returns null
@@ -194,6 +201,7 @@ class WatchingEpisodeModalViewModelTest {
                 every { title } returns "テスト作品"
                 every { viewerStatusState } returns StatusState.WATCHING
                 every { noEpisodes } returns false
+                every { malAnimeId } returns null
             }
             val entry = mockk<LibraryEntry> {
                 every { nextEpisode } returns null
@@ -233,6 +241,7 @@ class WatchingEpisodeModalViewModelTest {
                 every { title } returns "テスト作品"
                 every { viewerStatusState } returns StatusState.WATCHING
                 every { noEpisodes } returns false
+                every { malAnimeId } returns null
             }
             val entry = mockk<LibraryEntry> {
                 every { nextEpisode } returns episode
@@ -265,6 +274,7 @@ class WatchingEpisodeModalViewModelTest {
                 every { title } returns "テスト作品"
                 every { viewerStatusState } returns StatusState.WATCHING
                 every { noEpisodes } returns false
+                every { malAnimeId } returns null
             }
             val entry = mockk<LibraryEntry> {
                 every { nextEpisode } returns episode
@@ -293,6 +303,7 @@ class WatchingEpisodeModalViewModelTest {
                 every { title } returns "テスト作品"
                 every { viewerStatusState } returns StatusState.WATCHING
                 every { noEpisodes } returns false
+                every { malAnimeId } returns null
             }
             val entry = mockk<LibraryEntry> {
                 every { nextEpisode } returns null


### PR DESCRIPTION
## Summary

Issue #184対応。MyAnimeListでエピソード数が不明な場合でも、Annictの次話情報を活用して最終話判定の精度を向上させます。

## 変更内容

### 1. JudgeFinaleUseCaseのロジック改善
- `numEpisodes == null` でも `hasNextEpisode` 情報を活用
  - `hasNextEpisode == true` → **NOT_FINALE**（次話確定）
  - `hasNextEpisode != true` → **UNKNOWN**（判定不能）
- Annictの次話情報により判定精度が向上

### 2. UNKNOWNの場合も確認ダイアログ表示
- **BroadcastEpisodeModalViewModel**: UNKNOWN時もユーザーに確認
- **WatchingEpisodeModalViewModel**: ライブラリ画面でも同様に対応
- 最終話の可能性がある場合は必ずユーザーに判断を求める

### 3. UI改善
- **AnimeDetailScreen**: エピソード数不明時に「全?話」表示
- **WatchingEpisodeModal**: 最終話確認ダイアログ追加

### 4. テストケース追加
- `numEpisodes == null` のケースを網羅
- `hasNextEpisode` による判定ロジックをテスト
- ユニットテスト・統合テスト両方で対応

## 判定フロー

```
MyAnimeList numEpisodes:
├─ null の場合
│  ├─ hasNextEpisode == true  → NOT_FINALE（ダイアログなし）
│  ├─ hasNextEpisode == false → UNKNOWN（ユーザーに確認）
│  └─ hasNextEpisode == null  → UNKNOWN（ユーザーに確認）
└─ 数値の場合
   ├─ currentEp >= numEpisodes → FINALE_CONFIRMED（ユーザーに確認）
   └─ currentEp < numEpisodes  → NOT_FINALE（ダイアログなし）
```

## Test plan

- [x] ユニットテスト: 全199テスト成功
- [x] InstrumentationTest: 全92テスト成功
- [x] エピソード数不明でも次話情報で判定可能
- [x] 判定不能時はユーザーに確認ダイアログ表示
- [x] ライブラリ画面でも最終話判定動作確認

## Related Issues

Closes #184

## Screenshots

エピソード数不明時の表示：
- アニメ詳細: 「全?話」
- 最終話確認ダイアログ: 「このエピソードが最終話の可能性があります」

## Notes

**開発者向け：**
- エピソード数不明のアニメでも、Annictに次話情報があれば正確に判定可能
- 判定不能（UNKNOWN）の場合は必ずユーザーに確認するため、誤判定のリスクを低減