### PR TITLE
refactor: Unify Repository error handling with Result<T>

### DIFF
--- a/app/src/androidTest/java/com/zelretch/aniiiiict/testing/FakeAnnictRepository.kt
+++ b/app/src/androidTest/java/com/zelretch/aniiiiict/testing/FakeAnnictRepository.kt
@@ -1,0 +1,85 @@
+package com.zelretch.aniiiiict.testing
+
+import com.annict.ViewerProgramsQuery
+import com.annict.WorkDetailQuery
+import com.annict.type.StatusState
+import com.zelretch.aniiiiict.data.model.LibraryEntry
+import com.zelretch.aniiiiict.data.model.PaginatedRecords
+import com.zelretch.aniiiiict.data.repository.AnnictRepository
+
+/**
+ * MockKがkotlin.Result（inline class）を正しく扱えないため、
+ * instrumentation testではfake実装を使用する。
+ */
+open class FakeAnnictRepository : AnnictRepository {
+    var authenticated = true
+    var authUrl = "https://example.com/auth"
+    var getAuthUrlError: Throwable? = null
+    var handleAuthCallbackResult: Result<Unit> = Result.success(Unit)
+    var createRecordResult: Result<Unit> = Result.success(Unit)
+    var rawProgramsData: Result<List<ViewerProgramsQuery.Node?>> = Result.success(emptyList())
+    var recordsResult: Result<PaginatedRecords> = Result.success(PaginatedRecords(emptyList(), false, null))
+    var deleteRecordResult: Result<Unit> = Result.success(Unit)
+    var updateWorkViewStatusResult: Result<Unit> = Result.success(Unit)
+    var workDetailResult: Result<WorkDetailQuery.Node?> = Result.success(null)
+    var libraryEntriesResult: Result<List<LibraryEntry>> = Result.success(emptyList())
+
+    // 呼び出し記録
+    val createRecordCalls = mutableListOf<Pair<String, String>>()
+    val deleteRecordCalls = mutableListOf<String>()
+    val updateWorkViewStatusCalls = mutableListOf<Pair<String, StatusState>>()
+    val handleAuthCallbackCalls = mutableListOf<String>()
+    val getRecordsCalls = mutableListOf<String?>()
+    val getRawProgramsDataCallCount get() = _getRawProgramsDataCallCount
+    private var _getRawProgramsDataCallCount = 0
+    val isAuthenticatedCallCount get() = _isAuthenticatedCallCount
+    private var _isAuthenticatedCallCount = 0
+    val getAuthUrlCallCount get() = _getAuthUrlCallCount
+    private var _getAuthUrlCallCount = 0
+
+    override suspend fun isAuthenticated(): Boolean {
+        _isAuthenticatedCallCount++
+        return authenticated
+    }
+
+    override suspend fun getAuthUrl(): String {
+        _getAuthUrlCallCount++
+        getAuthUrlError?.let { throw it }
+        return authUrl
+    }
+
+    override suspend fun handleAuthCallback(code: String): Result<Unit> {
+        handleAuthCallbackCalls.add(code)
+        return handleAuthCallbackResult
+    }
+
+    override suspend fun createRecord(episodeId: String, workId: String): Result<Unit> {
+        createRecordCalls.add(episodeId to workId)
+        return createRecordResult
+    }
+
+    override suspend fun getRawProgramsData(): Result<List<ViewerProgramsQuery.Node?>> {
+        _getRawProgramsDataCallCount++
+        return rawProgramsData
+    }
+
+    override suspend fun getRecords(after: String?): Result<PaginatedRecords> {
+        getRecordsCalls.add(after)
+        return recordsResult
+    }
+
+    override suspend fun deleteRecord(recordId: String): Result<Unit> {
+        deleteRecordCalls.add(recordId)
+        return deleteRecordResult
+    }
+
+    override suspend fun updateWorkViewStatus(workId: String, state: StatusState): Result<Unit> {
+        updateWorkViewStatusCalls.add(workId to state)
+        return updateWorkViewStatusResult
+    }
+
+    override suspend fun getWorkDetail(workId: String): Result<WorkDetailQuery.Node?> = workDetailResult
+
+    override suspend fun getLibraryEntries(states: List<StatusState>, after: String?): Result<List<LibraryEntry>> =
+        libraryEntriesResult
+}

--- a/app/src/androidTest/java/com/zelretch/aniiiiict/ui/AppNavigationTest.kt
+++ b/app/src/androidTest/java/com/zelretch/aniiiiict/ui/AppNavigationTest.kt
@@ -10,14 +10,13 @@ import com.zelretch.aniiiiict.data.repository.AnnictRepository
 import com.zelretch.aniiiiict.data.repository.MyAnimeListRepository
 import com.zelretch.aniiiiict.di.AppModule
 import com.zelretch.aniiiiict.domain.filter.ProgramFilter
+import com.zelretch.aniiiiict.testing.FakeAnnictRepository
 import com.zelretch.aniiiiict.ui.base.CustomTabsIntentFactory
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
-import io.mockk.coEvery
 import io.mockk.mockk
-import kotlinx.coroutines.flow.flowOf
 import org.junit.Rule
 import org.junit.Test
 
@@ -33,10 +32,7 @@ class AppNavigationTest {
 
     @BindValue
     @JvmField
-    val mockAnnictRepository: AnnictRepository = mockk(relaxed = true) {
-        coEvery { getRawProgramsData() } returns flowOf(emptyList())
-        coEvery { isAuthenticated() } returns true
-    }
+    val mockAnnictRepository: AnnictRepository = FakeAnnictRepository()
 
     @BindValue
     @JvmField

--- a/app/src/androidTest/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailScreenIntegrationTest.kt
+++ b/app/src/androidTest/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailScreenIntegrationTest.kt
@@ -98,16 +98,21 @@ class AnimeDetailScreenIntegrationTest {
 
             override suspend fun isAuthenticated(): Boolean = true
             override suspend fun getAuthUrl(): String = "https://example.com/auth"
-            override suspend fun handleAuthCallback(code: String): Boolean = true
-            override suspend fun createRecord(episodeId: String, workId: String): Boolean = true
-            override suspend fun getRawProgramsData() =
-                kotlinx.coroutines.flow.flowOf(emptyList<com.annict.ViewerProgramsQuery.Node>())
-            override suspend fun getRecords(after: String?) =
-                com.zelretch.aniiiiict.data.model.PaginatedRecords(emptyList(), false, null)
-            override suspend fun deleteRecord(recordId: String): Boolean = true
-            override suspend fun updateWorkViewStatus(workId: String, status: StatusState): Boolean = true
-            override suspend fun getLibraryEntries(states: List<StatusState>, after: String?) =
-                kotlinx.coroutines.flow.flowOf(emptyList<com.zelretch.aniiiiict.data.model.LibraryEntry>())
+            override suspend fun handleAuthCallback(code: String): Result<Unit> = Result.success(Unit)
+            override suspend fun createRecord(episodeId: String, workId: String): Result<Unit> = Result.success(Unit)
+            override suspend fun getRawProgramsData(): Result<List<com.annict.ViewerProgramsQuery.Node?>> =
+                Result.success(emptyList())
+            override suspend fun getRecords(
+                after: String?
+            ): Result<com.zelretch.aniiiiict.data.model.PaginatedRecords> =
+                Result.success(com.zelretch.aniiiiict.data.model.PaginatedRecords(emptyList(), false, null))
+            override suspend fun deleteRecord(recordId: String): Result<Unit> = Result.success(Unit)
+            override suspend fun updateWorkViewStatus(workId: String, status: StatusState): Result<Unit> =
+                Result.success(Unit)
+            override suspend fun getLibraryEntries(
+                states: List<StatusState>,
+                after: String?
+            ): Result<List<com.zelretch.aniiiiict.data.model.LibraryEntry>> = Result.success(emptyList())
         }
 
         // Fake MyAnimeList Repository
@@ -160,16 +165,21 @@ class AnimeDetailScreenIntegrationTest {
 
             override suspend fun isAuthenticated(): Boolean = true
             override suspend fun getAuthUrl(): String = "https://example.com/auth"
-            override suspend fun handleAuthCallback(code: String): Boolean = true
-            override suspend fun createRecord(episodeId: String, workId: String): Boolean = true
-            override suspend fun getRawProgramsData() =
-                kotlinx.coroutines.flow.flowOf(emptyList<com.annict.ViewerProgramsQuery.Node>())
-            override suspend fun getRecords(after: String?) =
-                com.zelretch.aniiiiict.data.model.PaginatedRecords(emptyList(), false, null)
-            override suspend fun deleteRecord(recordId: String): Boolean = true
-            override suspend fun updateWorkViewStatus(workId: String, status: StatusState): Boolean = true
-            override suspend fun getLibraryEntries(states: List<StatusState>, after: String?) =
-                kotlinx.coroutines.flow.flowOf(emptyList<com.zelretch.aniiiiict.data.model.LibraryEntry>())
+            override suspend fun handleAuthCallback(code: String): Result<Unit> = Result.success(Unit)
+            override suspend fun createRecord(episodeId: String, workId: String): Result<Unit> = Result.success(Unit)
+            override suspend fun getRawProgramsData(): Result<List<com.annict.ViewerProgramsQuery.Node?>> =
+                Result.success(emptyList())
+            override suspend fun getRecords(
+                after: String?
+            ): Result<com.zelretch.aniiiiict.data.model.PaginatedRecords> =
+                Result.success(com.zelretch.aniiiiict.data.model.PaginatedRecords(emptyList(), false, null))
+            override suspend fun deleteRecord(recordId: String): Result<Unit> = Result.success(Unit)
+            override suspend fun updateWorkViewStatus(workId: String, status: StatusState): Result<Unit> =
+                Result.success(Unit)
+            override suspend fun getLibraryEntries(
+                states: List<StatusState>,
+                after: String?
+            ): Result<List<com.zelretch.aniiiiict.data.model.LibraryEntry>> = Result.success(emptyList())
         }
 
         // Fake MyAnimeList Repository
@@ -241,8 +251,7 @@ class AnimeDetailScreenIntegrationTest {
 
         return ProgramWithWork(
             work = work,
-            programs = listOf(program),
-            firstProgram = program
+            programs = listOf(program)
         )
     }
 

--- a/app/src/androidTest/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailScreenUITest.kt
+++ b/app/src/androidTest/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailScreenUITest.kt
@@ -297,8 +297,7 @@ class AnimeDetailScreenUITest {
 
         return ProgramWithWork(
             work = work,
-            programs = listOf(program),
-            firstProgram = program
+            programs = listOf(program)
         )
     }
 

--- a/app/src/androidTest/java/com/zelretch/aniiiiict/ui/library/WatchingEpisodeModalIntegrationTest.kt
+++ b/app/src/androidTest/java/com/zelretch/aniiiiict/ui/library/WatchingEpisodeModalIntegrationTest.kt
@@ -15,16 +15,16 @@ import com.zelretch.aniiiiict.domain.filter.ProgramFilter
 import com.zelretch.aniiiiict.domain.usecase.JudgeFinaleUseCase
 import com.zelretch.aniiiiict.domain.usecase.UpdateViewStateUseCase
 import com.zelretch.aniiiiict.domain.usecase.WatchEpisodeUseCase
+import com.zelretch.aniiiiict.testing.FakeAnnictRepository
 import com.zelretch.aniiiiict.testing.HiltComposeTestRule
 import com.zelretch.aniiiiict.ui.base.CustomTabsIntentFactory
 import com.zelretch.aniiiiict.ui.base.ErrorMapper
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
-import io.mockk.coEvery
-import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import javax.inject.Inject
@@ -53,12 +53,11 @@ class WatchingEpisodeModalIntegrationTest {
     @Inject
     lateinit var errorMapper: ErrorMapper
 
+    private val fakeAnnictRepository = FakeAnnictRepository()
+
     @BindValue
     @JvmField
-    val annictRepository: AnnictRepository = mockk<AnnictRepository>().apply {
-        coEvery { updateWorkViewStatus(any(), any()) } returns true
-        coEvery { createRecord(any(), any()) } returns true
-    }
+    val annictRepository: AnnictRepository = fakeAnnictRepository
 
     @BindValue
     @JvmField
@@ -113,7 +112,9 @@ class WatchingEpisodeModalIntegrationTest {
         testRule.composeTestRule.waitForIdle()
 
         // Assert - AnnictRepository.createRecordが呼ばれたことを確認
-        coVerify { annictRepository.createRecord("ep-test", any()) }
+        assertTrue(
+            fakeAnnictRepository.createRecordCalls.any { it.first == "ep-test" }
+        )
     }
 
     @Test
@@ -153,7 +154,9 @@ class WatchingEpisodeModalIntegrationTest {
         testRule.composeTestRule.waitForIdle()
 
         // Assert - AnnictRepository.updateWorkViewStatusが呼ばれたことを確認
-        coVerify { annictRepository.updateWorkViewStatus("work-status", StatusState.WATCHED) }
+        assertTrue(
+            fakeAnnictRepository.updateWorkViewStatusCalls.contains("work-status" to StatusState.WATCHED)
+        )
     }
 
     @Test

--- a/app/src/androidTest/java/com/zelretch/aniiiiict/ui/track/BroadcastEpisodeModalUITest.kt
+++ b/app/src/androidTest/java/com/zelretch/aniiiiict/ui/track/BroadcastEpisodeModalUITest.kt
@@ -69,7 +69,6 @@ class BroadcastEpisodeModalUITest {
         )
         return ProgramWithWork(
             programs = listOf(program),
-            firstProgram = program,
             work = work
         )
     }
@@ -200,7 +199,6 @@ class BroadcastEpisodeModalUITest {
         )
         val programWithWork = ProgramWithWork(
             programs = listOf(program1, program2),
-            firstProgram = program1,
             work = work
         )
 
@@ -349,7 +347,6 @@ class BroadcastEpisodeModalUITest {
         }
         val programWithWork = ProgramWithWork(
             programs = programs,
-            firstProgram = programs.first(),
             work = work
         )
         val viewModel = createMockViewModel(programWithWork)

--- a/app/src/androidTest/java/com/zelretch/aniiiiict/ui/track/TrackScreenUITest.kt
+++ b/app/src/androidTest/java/com/zelretch/aniiiiict/ui/track/TrackScreenUITest.kt
@@ -143,7 +143,6 @@ class TrackScreenUITest {
 
         val programWithWork = ProgramWithWork(
             programs = listOf(sampleProgram),
-            firstProgram = sampleProgram,
             work = sampleWork
         )
 
@@ -201,7 +200,6 @@ class TrackScreenUITest {
 
         val programWithWork = ProgramWithWork(
             programs = listOf(sampleProgram),
-            firstProgram = sampleProgram,
             work = sampleWork
         )
 
@@ -338,7 +336,6 @@ class TrackScreenUITest {
         )
         val programWithWork = ProgramWithWork(
             programs = listOf(sampleProgram),
-            firstProgram = sampleProgram,
             work = sampleWork
         )
         val state = TrackUiState(programs = listOf(programWithWork))

--- a/app/src/main/java/com/zelretch/aniiiiict/data/model/ProgramWithWork.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/data/model/ProgramWithWork.kt
@@ -1,3 +1,5 @@
 package com.zelretch.aniiiiict.data.model
 
-data class ProgramWithWork(var programs: List<Program>, val firstProgram: Program, val work: Work)
+data class ProgramWithWork(val programs: List<Program>, val work: Work) {
+    val firstProgram: Program get() = programs.first()
+}

--- a/app/src/main/java/com/zelretch/aniiiiict/data/repository/AnnictRepository.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/data/repository/AnnictRepository.kt
@@ -3,21 +3,18 @@ package com.zelretch.aniiiiict.data.repository
 import com.annict.ViewerProgramsQuery
 import com.annict.WorkDetailQuery
 import com.annict.type.StatusState
+import com.zelretch.aniiiiict.data.model.LibraryEntry
 import com.zelretch.aniiiiict.data.model.PaginatedRecords
-import kotlinx.coroutines.flow.Flow
 
 interface AnnictRepository {
     suspend fun isAuthenticated(): Boolean
     suspend fun getAuthUrl(): String
-    suspend fun handleAuthCallback(code: String): Boolean
-    suspend fun createRecord(episodeId: String, workId: String): Boolean
-    suspend fun getRawProgramsData(): Flow<List<ViewerProgramsQuery.Node?>>
-    suspend fun getRecords(after: String? = null): PaginatedRecords
-    suspend fun deleteRecord(recordId: String): Boolean
-    suspend fun updateWorkViewStatus(workId: String, state: StatusState): Boolean
+    suspend fun handleAuthCallback(code: String): Result<Unit>
+    suspend fun createRecord(episodeId: String, workId: String): Result<Unit>
+    suspend fun getRawProgramsData(): Result<List<ViewerProgramsQuery.Node?>>
+    suspend fun getRecords(after: String? = null): Result<PaginatedRecords>
+    suspend fun deleteRecord(recordId: String): Result<Unit>
+    suspend fun updateWorkViewStatus(workId: String, state: StatusState): Result<Unit>
     suspend fun getWorkDetail(workId: String): Result<WorkDetailQuery.Node?>
-    suspend fun getLibraryEntries(
-        states: List<StatusState>,
-        after: String? = null
-    ): Flow<List<com.zelretch.aniiiiict.data.model.LibraryEntry>>
+    suspend fun getLibraryEntries(states: List<StatusState>, after: String? = null): Result<List<LibraryEntry>>
 }

--- a/app/src/main/java/com/zelretch/aniiiiict/data/repository/AnnictRepositoryImpl.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/data/repository/AnnictRepositoryImpl.kt
@@ -13,14 +13,14 @@ import com.zelretch.aniiiiict.data.api.AnnictApolloClient
 import com.zelretch.aniiiiict.data.auth.AnnictAuthManager
 import com.zelretch.aniiiiict.data.auth.TokenManager
 import com.zelretch.aniiiiict.data.model.Episode
+import com.zelretch.aniiiiict.data.model.LibraryEntry
 import com.zelretch.aniiiiict.data.model.PaginatedRecords
 import com.zelretch.aniiiiict.data.model.Record
 import com.zelretch.aniiiiict.data.model.Work
 import com.zelretch.aniiiiict.data.model.WorkImage
+import com.zelretch.aniiiiict.domain.error.DomainError
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.isActive
 import timber.log.Timber
 import java.io.IOException
@@ -47,24 +47,16 @@ class AnnictRepositoryImpl @Inject constructor(
 
     override suspend fun getAuthUrl(): String = authManager.getAuthorizationUrl()
 
-    override suspend fun createRecord(episodeId: String, workId: String): Boolean {
-        // パラメータバリデーション（APIリクエスト前に行う必要あり）
+    override suspend fun createRecord(episodeId: String, workId: String): Result<Unit> {
         if (episodeId.isEmpty() || workId.isEmpty()) {
             Timber.e("エピソードIDまたは作品IDがnullまたは空です")
-            return false
-        }
-
-        // executeApiRequest を使わず、予期しない例外は上位へスローしてテスト期待に合わせる
-        val token = tokenManager.getAccessToken()
-        if (!currentCoroutineContext().isActive || token.isNullOrEmpty()) {
-            Timber.w("リクエスト実行の前提条件未達、または処理キャンセル: operation=createRecord, tokenIsEmpty=${token.isNullOrEmpty()}")
-            return false
-        }
-
-        return try {
-            Timber.i(
-                "エピソード記録を実行: episodeId=$episodeId, workId=$workId"
+            return Result.failure(
+                DomainError.ValidationError.MissingRequiredParameter("episodeId or workId")
             )
+        }
+
+        return executeApiRequest("createRecord") {
+            Timber.i("エピソード記録を実行: episodeId=$episodeId, workId=$workId")
 
             val mutation = CreateRecordMutation(episodeId = episodeId)
             val response = annictApolloClient.executeMutation(
@@ -72,177 +64,103 @@ class AnnictRepositoryImpl @Inject constructor(
                 context = "AnnictRepositoryImpl.createRecord"
             )
 
-            Timber.i(
-                "GraphQLのレスポンス: ${response.data != null}, エラー: ${response.errors}"
-            )
+            Timber.i("GraphQLのレスポンス: ${response.data != null}, エラー: ${response.errors}")
 
-            !response.hasErrors()
-        } catch (e: ApolloException) {
-            Timber.e(e, "[AnnictRepositoryImpl][createRecord] API error while creating record")
-            false
-        } catch (e: IOException) {
-            Timber.e(e, "[AnnictRepositoryImpl][createRecord] Network IO error while creating record")
-            false
-        }
-    }
-
-    override suspend fun handleAuthCallback(code: String): Boolean {
-        Timber.i(
-            "認証コールバック処理開始 - コード: ${code.take(AUTH_CODE_LOG_LENGTH)}..."
-        )
-        return try {
-            authManager.handleAuthorizationCode(code).fold(onSuccess = {
-                Timber.i("認証成功")
-                true
-            }, onFailure = { e ->
-                Timber.e(
-                    e,
-                    "認証失敗"
-                )
-                false
-            })
-        } catch (e: ApolloException) {
-            Timber.e(e, "[AnnictRepositoryImpl][exchangeCodeForToken] API error while handling auth callback")
-            false
-        } catch (e: IOException) {
-            Timber.e(e, "[AnnictRepositoryImpl][exchangeCodeForToken] Network IO error while handling auth callback")
-            false
-        } catch (e: Exception) {
-            Timber.e(e, "[AnnictRepositoryImpl][exchangeCodeForToken] Unexpected error while handling auth callback")
-            false
-        }
-    }
-
-    override suspend fun getRawProgramsData(): Flow<List<ViewerProgramsQuery.Node?>> {
-        return flow {
-            try {
-                Timber.i("プログラム一覧の取得を開始")
-
-                // キャンセルされた場合は例外をスローせずに空のリストを返す
-                if (!currentCoroutineContext().isActive) {
-                    Timber.i(
-                        "処理がキャンセルされたため、実行をスキップします"
-                    )
-                    emit(emptyList())
-                    return@flow
-                }
-
-                // アクセストークンの確認
-                val token = tokenManager.getAccessToken()
-                if (token.isNullOrEmpty()) {
-                    Timber.e(
-                        "アクセストークンがありません"
-                    )
-                    emit(emptyList())
-                    return@flow
-                }
-
-                val query = ViewerProgramsQuery()
-                val response = annictApolloClient.executeQuery(
-                    operation = query,
-                    context = "AnnictRepositoryImpl.getRawProgramsData"
-                )
-
-                Timber.i(
-                    "GraphQLのレスポンス: ${response.data != null}"
-                )
-
-                if (response.hasErrors()) {
-                    Timber.e(
-                        "GraphQLエラー: ${response.errors}"
-                    )
-                    emit(emptyList())
-                    return@flow
-                }
-
-                val programs = response.data?.viewer?.programs?.nodes
-                Timber.i(
-                    "取得したプログラム数: ${programs?.size ?: 0}"
-                )
-
-                emit(programs ?: emptyList())
-            } catch (e: ApolloException) {
-                Timber.e(e, "[AnnictRepositoryImpl][getRawProgramsData] API error during fetching programs")
-                emit(emptyList())
-            } catch (e: IOException) {
-                Timber.e(e, "[AnnictRepositoryImpl][getRawProgramsData] Network IO error during fetching programs")
-                emit(emptyList())
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Timber.e(e, "[AnnictRepositoryImpl][getRawProgramsData] Unexpected error during fetching programs")
-                emit(emptyList())
+            if (response.hasErrors()) {
+                throw DomainError.BusinessError.RecordCreationFailed()
             }
         }
     }
 
-    override suspend fun getRecords(after: String?): PaginatedRecords = executeApiRequest(
-        operation = "getRecords",
-        defaultValue = PaginatedRecords(emptyList())
-    ) {
+    override suspend fun handleAuthCallback(code: String): Result<Unit> {
+        Timber.i("認証コールバック処理開始 - コード: ${code.take(AUTH_CODE_LOG_LENGTH)}...")
+        return executeApiRequest("handleAuthCallback") {
+            authManager.handleAuthorizationCode(code).getOrElse { e ->
+                throw DomainError.AuthError.CallbackFailed(e)
+            }
+            Timber.i("認証成功")
+        }
+    }
+
+    override suspend fun getRawProgramsData(): Result<List<ViewerProgramsQuery.Node?>> =
+        executeApiRequest("getRawProgramsData") {
+            Timber.i("プログラム一覧の取得を開始")
+
+            val query = ViewerProgramsQuery()
+            val response = annictApolloClient.executeQuery(
+                operation = query,
+                context = "AnnictRepositoryImpl.getRawProgramsData"
+            )
+
+            Timber.i("GraphQLのレスポンス: ${response.data != null}")
+
+            if (response.hasErrors()) {
+                Timber.e("GraphQLエラー: ${response.errors}")
+                throw DomainError.ApiError.GraphQLError("Programs query failed: ${response.errors}")
+            }
+
+            val programs = response.data?.viewer?.programs?.nodes
+            Timber.i("取得したプログラム数: ${programs?.size ?: 0}")
+            programs ?: emptyList()
+        }
+
+    override suspend fun getRecords(after: String?): Result<PaginatedRecords> = executeApiRequest("getRecords") {
         Timber.i("記録履歴を取得中...")
 
-        val query = ViewerRecordsQuery(after = after?.let { Optional.present(it) } ?: Optional.absent())
+        val query = ViewerRecordsQuery(
+            after = after?.let { Optional.present(it) } ?: Optional.absent()
+        )
         val response = annictApolloClient.executeQuery(
             operation = query,
             context = "AnnictRepositoryImpl.getRecords"
         )
 
-        if (!response.hasErrors()) {
-            val nodes = response.data?.viewer?.records?.nodes ?: emptyList()
-            val pageInfo = response.data?.viewer?.records?.pageInfo
-            val records = nodes.mapNotNull { node ->
-                node?.let {
-                    val episode = it.episode
-                    val work = episode.work
-
-                    Record(
-                        id = it.id,
-                        comment = it.comment,
-                        rating = it.rating,
-                        createdAt = ZonedDateTime.parse(it.createdAt.toString()),
-                        episode = Episode(
-                            id = episode.id,
-                            number = null,
-                            numberText = episode.numberText ?: "",
-                            title = episode.title ?: "",
-                            viewerDidTrack = episode.viewerDidTrack
-                        ),
-                        work = Work(
-                            id = work.id,
-                            title = work.title,
-                            media = null,
-                            mediaText = "",
-                            viewerStatusState = StatusState.UNKNOWN__,
-                            seasonNameText = ""
-                        )
-                    )
-                }
-            }
-
-            Timber.i(
-                "${records.size}件の記録を取得しました"
-            )
-            PaginatedRecords(
-                records = records,
-                hasNextPage = pageInfo?.hasNextPage == true,
-                endCursor = pageInfo?.endCursor
-            )
-        } else {
-            Timber.e(
-                "GraphQLエラー: ${response.errors}"
-            )
-            PaginatedRecords(emptyList())
+        if (response.hasErrors()) {
+            Timber.e("GraphQLエラー: ${response.errors}")
+            throw DomainError.BusinessError.RecordsLoadFailed()
         }
+
+        val nodes = response.data?.viewer?.records?.nodes ?: emptyList()
+        val pageInfo = response.data?.viewer?.records?.pageInfo
+        val records = nodes.mapNotNull { node ->
+            node?.let {
+                val episode = it.episode
+                val work = episode.work
+
+                Record(
+                    id = it.id,
+                    comment = it.comment,
+                    rating = it.rating,
+                    createdAt = ZonedDateTime.parse(it.createdAt.toString()),
+                    episode = Episode(
+                        id = episode.id,
+                        number = null,
+                        numberText = episode.numberText ?: "",
+                        title = episode.title ?: "",
+                        viewerDidTrack = episode.viewerDidTrack
+                    ),
+                    work = Work(
+                        id = work.id,
+                        title = work.title,
+                        media = null,
+                        mediaText = "",
+                        viewerStatusState = StatusState.UNKNOWN__,
+                        seasonNameText = ""
+                    )
+                )
+            }
+        }
+
+        Timber.i("${records.size}件の記録を取得しました")
+        PaginatedRecords(
+            records = records,
+            hasNextPage = pageInfo?.hasNextPage == true,
+            endCursor = pageInfo?.endCursor
+        )
     }
 
-    override suspend fun deleteRecord(recordId: String): Boolean = executeApiRequest(
-        operation = "deleteRecord",
-        defaultValue = false
-    ) {
-        Timber.i(
-            "記録を削除中: $recordId"
-        )
+    override suspend fun deleteRecord(recordId: String): Result<Unit> = executeApiRequest("deleteRecord") {
+        Timber.i("記録を削除中: $recordId")
 
         val mutation = DeleteRecordMutation(recordId)
         val response = annictApolloClient.executeMutation(
@@ -250,87 +168,55 @@ class AnnictRepositoryImpl @Inject constructor(
             context = "AnnictRepositoryImpl.deleteRecord"
         )
 
-        if (!response.hasErrors()) {
-            Timber.i(
-                "記録を削除しました: $recordId"
-            )
-            true
-        } else {
-            Timber.e(
-                "GraphQLエラー: ${response.errors}"
-            )
-            false
+        if (response.hasErrors()) {
+            Timber.e("GraphQLエラー: ${response.errors}")
+            throw DomainError.BusinessError.RecordDeletionFailed()
         }
+
+        Timber.i("記録を削除しました: $recordId")
     }
 
-    override suspend fun updateWorkViewStatus(workId: String, state: StatusState): Boolean = executeApiRequest(
-        operation = "updateWorkStatus",
-        defaultValue = false
-    ) {
-        Timber.i(
-            "作品ステータスを更新中: workId=$workId, state=$state"
-        )
+    override suspend fun updateWorkViewStatus(workId: String, state: StatusState): Result<Unit> =
+        executeApiRequest("updateWorkStatus") {
+            Timber.i("作品ステータスを更新中: workId=$workId, state=$state")
 
-        val mutation = UpdateStatusMutation(workId = workId, state = state)
-        val response = annictApolloClient.executeMutation(
-            operation = mutation,
-            context = "AnnictRepositoryImpl.updateWorkStatus"
-        )
+            val mutation = UpdateStatusMutation(workId = workId, state = state)
+            val response = annictApolloClient.executeMutation(
+                operation = mutation,
+                context = "AnnictRepositoryImpl.updateWorkStatus"
+            )
 
-        if (!response.hasErrors()) {
-            Timber.i(
-                "作品ステータスを更新しました: workId=$workId, state=$state"
-            )
-            true
-        } else {
-            Timber.e(
-                "GraphQLエラー: ${response.errors}"
-            )
-            false
+            if (response.hasErrors()) {
+                Timber.e("GraphQLエラー: ${response.errors}")
+                throw DomainError.BusinessError.StatusUpdateFailed()
+            }
+
+            Timber.i("作品ステータスを更新しました: workId=$workId, state=$state")
         }
-    }
 
-    override suspend fun getWorkDetail(workId: String): Result<WorkDetailQuery.Node?> = executeApiRequest(
-        operation = "getWorkDetail",
-        defaultValue = Result.failure(IOException("Work detail request failed"))
-    ) {
-        Timber.i("作品詳細情報を取得中: workId=$workId")
+    override suspend fun getWorkDetail(workId: String): Result<WorkDetailQuery.Node?> =
+        executeApiRequest("getWorkDetail") {
+            Timber.i("作品詳細情報を取得中: workId=$workId")
 
-        val query = WorkDetailQuery(workId = workId)
-        val response = annictApolloClient.executeQuery(
-            operation = query,
-            context = "AnnictRepositoryImpl.getWorkDetail"
-        )
+            val query = WorkDetailQuery(workId = workId)
+            val response = annictApolloClient.executeQuery(
+                operation = query,
+                context = "AnnictRepositoryImpl.getWorkDetail"
+            )
 
-        if (!response.hasErrors()) {
+            if (response.hasErrors()) {
+                Timber.e("GraphQLエラー: ${response.errors}")
+                throw DomainError.ApiError.GraphQLError("Work detail query failed: ${response.errors}")
+            }
+
             val node = response.data?.node
             Timber.i("作品詳細情報を取得しました: workId=$workId")
-            Result.success(node)
-        } else {
-            Timber.e("GraphQLエラー: ${response.errors}")
-            Result.failure(IOException("GraphQL error: ${response.errors}"))
+            node
         }
-    }
 
-    override suspend fun getLibraryEntries(
-        states: List<StatusState>,
-        after: String?
-    ): Flow<List<com.zelretch.aniiiiict.data.model.LibraryEntry>> = flow {
-        try {
+    override suspend fun getLibraryEntries(states: List<StatusState>, after: String?): Result<List<LibraryEntry>> =
+        executeApiRequest("getLibraryEntries") {
             Timber.i("ライブラリエントリー一覧の取得を開始: states=$states")
-
-            if (!currentCoroutineContext().isActive) {
-                Timber.i("処理がキャンセルされたため、実行をスキップします")
-                emit(emptyList())
-                return@flow
-            }
-
-            val token = tokenManager.getAccessToken()
-            if (token.isNullOrEmpty()) {
-                Timber.e("アクセストークンがありません")
-                emit(emptyList())
-                return@flow
-            }
 
             val query = com.annict.ViewerLibraryEntriesQuery(
                 states = Optional.present(states),
@@ -345,35 +231,19 @@ class AnnictRepositoryImpl @Inject constructor(
 
             if (response.hasErrors()) {
                 Timber.e("GraphQLエラー: ${response.errors}")
-                emit(emptyList())
-                return@flow
+                throw DomainError.ApiError.GraphQLError("Library entries query failed: ${response.errors}")
             }
 
             val nodes = response.data?.viewer?.libraryEntries?.nodes?.filterNotNull() ?: emptyList()
             val entries = nodes.mapNotNull { node -> mapToLibraryEntry(node) }
 
             Timber.i("ライブラリエントリー一覧を取得しました: ${entries.size}件")
-            emit(entries)
-        } catch (e: ApolloException) {
-            Timber.e(e, "Apollo APIエラー")
-            emit(emptyList())
-        } catch (e: IOException) {
-            Timber.e(e, "ネットワークIOエラー")
-            emit(emptyList())
-        } catch (e: CancellationException) {
-            Timber.w("処理がキャンセルされました")
-            throw e
-        } catch (e: Exception) {
-            Timber.e(e, "予期しないエラー")
-            emit(emptyList())
+            entries
         }
-    }
 
-    private fun mapToLibraryEntry(
-        node: com.annict.ViewerLibraryEntriesQuery.Node
-    ): com.zelretch.aniiiiict.data.model.LibraryEntry? {
+    private fun mapToLibraryEntry(node: com.annict.ViewerLibraryEntriesQuery.Node): LibraryEntry? {
         val viewerStatus = node.work.viewerStatusState ?: return null
-        return com.zelretch.aniiiiict.data.model.LibraryEntry(
+        return LibraryEntry(
             id = node.id,
             work = Work(
                 id = node.work.id,
@@ -385,7 +255,7 @@ class AnnictRepositoryImpl @Inject constructor(
                 viewerStatusState = viewerStatus,
                 noEpisodes = node.work.noEpisodes,
                 image = node.work.image?.let { image ->
-                    com.zelretch.aniiiiict.data.model.WorkImage(
+                    WorkImage(
                         recommendedImageUrl = image.recommendedImageUrl,
                         facebookOgImageUrl = image.facebookOgImageUrl
                     )
@@ -403,27 +273,36 @@ class AnnictRepositoryImpl @Inject constructor(
         )
     }
 
-    // 共通のAPIリクエスト処理を行うヘルパーメソッド
-    private suspend fun <T> executeApiRequest(operation: String, defaultValue: T, request: suspend () -> T): T {
+    /**
+     * 共通のAPIリクエスト処理を行うヘルパーメソッド
+     * エラーをDomainErrorにマッピングしてResult<T>で返す
+     */
+    private suspend fun <T> executeApiRequest(operation: String, request: suspend () -> T): Result<T> {
         val token = tokenManager.getAccessToken()
-        if (!currentCoroutineContext().isActive || token.isNullOrEmpty()) {
-            Timber.w("リクエスト実行の前提条件未達、または処理キャンセル: operation=$operation, tokenIsEmpty=${token.isNullOrEmpty()}")
-            return defaultValue
+        if (!currentCoroutineContext().isActive) {
+            return Result.failure(DomainError.Unknown("処理がキャンセルされました"))
+        }
+        if (token.isNullOrEmpty()) {
+            Timber.w("トークンが未設定: operation=$operation")
+            return Result.failure(DomainError.AuthError.InvalidToken())
         }
 
         return try {
-            request()
-        } catch (e: ApolloException) {
-            Timber.e(e, "[AnnictRepositoryImpl][$operation] API error during request")
-            defaultValue
-        } catch (e: IOException) {
-            Timber.e(e, "[AnnictRepositoryImpl][$operation] Network IO error during request")
-            defaultValue
+            Result.success(request())
         } catch (e: CancellationException) {
             throw e
+        } catch (e: DomainError) {
+            Timber.e(e, "[$operation] Domain error")
+            Result.failure(e)
+        } catch (e: ApolloException) {
+            Timber.e(e, "[$operation] API error")
+            Result.failure(DomainError.ApiError.Unknown(e))
+        } catch (e: IOException) {
+            Timber.e(e, "[$operation] Network IO error")
+            Result.failure(DomainError.NetworkError.NoConnection(e))
         } catch (e: Exception) {
-            Timber.e(e, "[AnnictRepositoryImpl][$operation] Unexpected error during request")
-            defaultValue
+            Timber.e(e, "[$operation] Unexpected error")
+            Result.failure(DomainError.Unknown(cause = e))
         }
     }
 }

--- a/app/src/main/java/com/zelretch/aniiiiict/domain/usecase/AnnictAuthUseCase.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/domain/usecase/AnnictAuthUseCase.kt
@@ -1,6 +1,7 @@
 package com.zelretch.aniiiiict.domain.usecase
 
 import com.zelretch.aniiiiict.data.repository.AnnictRepository
+import com.zelretch.aniiiiict.domain.error.DomainError
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -10,9 +11,9 @@ class AnnictAuthUseCase @Inject constructor(private val repository: AnnictReposi
 
     suspend fun getAuthUrl(): String = repository.getAuthUrl()
 
-    suspend fun handleAuthCallback(code: String?): Boolean = if (code != null) {
+    suspend fun handleAuthCallback(code: String?): Result<Unit> = if (code != null) {
         repository.handleAuthCallback(code)
     } else {
-        false
+        Result.failure(DomainError.AuthError.CallbackFailed())
     }
 }

--- a/app/src/main/java/com/zelretch/aniiiiict/domain/usecase/BulkRecordEpisodesUseCase.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/domain/usecase/BulkRecordEpisodesUseCase.kt
@@ -49,12 +49,6 @@ class BulkRecordEpisodesUseCase @Inject constructor(
             }
 
             BulkRecordResult(finaleResult = finaleResult)
-        }.fold(
-            onSuccess = { Result.success(it) },
-            onFailure = { e ->
-                // Bulk のエラーハンドリングでは元例外をそのまま返してテスト期待に合わせる
-                Result.failure(e)
-            }
-        )
+        }
     }
 }

--- a/app/src/main/java/com/zelretch/aniiiiict/domain/usecase/DeleteRecordUseCase.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/domain/usecase/DeleteRecordUseCase.kt
@@ -4,5 +4,5 @@ import com.zelretch.aniiiiict.data.repository.AnnictRepository
 import javax.inject.Inject
 
 class DeleteRecordUseCase @Inject constructor(private val repository: AnnictRepository) {
-    suspend operator fun invoke(recordId: String): Boolean = repository.deleteRecord(recordId)
+    suspend operator fun invoke(recordId: String): Result<Unit> = repository.deleteRecord(recordId)
 }

--- a/app/src/main/java/com/zelretch/aniiiiict/domain/usecase/LoadLibraryEntriesUseCase.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/domain/usecase/LoadLibraryEntriesUseCase.kt
@@ -3,12 +3,11 @@ package com.zelretch.aniiiiict.domain.usecase
 import com.annict.type.StatusState
 import com.zelretch.aniiiiict.data.model.LibraryEntry
 import com.zelretch.aniiiiict.data.repository.AnnictRepository
-import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class LoadLibraryEntriesUseCase @Inject constructor(
     private val repository: AnnictRepository
 ) {
-    suspend operator fun invoke(states: List<StatusState> = listOf(StatusState.WATCHING)): Flow<List<LibraryEntry>> =
+    suspend operator fun invoke(states: List<StatusState> = listOf(StatusState.WATCHING)): Result<List<LibraryEntry>> =
         repository.getLibraryEntries(states)
 }

--- a/app/src/main/java/com/zelretch/aniiiiict/domain/usecase/LoadRecordsUseCase.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/domain/usecase/LoadRecordsUseCase.kt
@@ -1,22 +1,9 @@
 package com.zelretch.aniiiiict.domain.usecase
 
-import com.zelretch.aniiiiict.data.model.Record
+import com.zelretch.aniiiiict.data.model.PaginatedRecords
 import com.zelretch.aniiiiict.data.repository.AnnictRepository
 import javax.inject.Inject
 
-data class RecordsResult(
-    val records: List<Record>,
-    val hasNextPage: Boolean,
-    val endCursor: String?
-)
-
 class LoadRecordsUseCase @Inject constructor(private val repository: AnnictRepository) {
-    suspend operator fun invoke(cursor: String? = null): RecordsResult {
-        val result = repository.getRecords(cursor)
-        return RecordsResult(
-            records = result.records,
-            hasNextPage = result.hasNextPage,
-            endCursor = result.endCursor
-        )
-    }
+    suspend operator fun invoke(cursor: String? = null): Result<PaginatedRecords> = repository.getRecords(cursor)
 }

--- a/app/src/main/java/com/zelretch/aniiiiict/domain/usecase/UpdateViewStateUseCase.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/domain/usecase/UpdateViewStateUseCase.kt
@@ -2,22 +2,11 @@ package com.zelretch.aniiiiict.domain.usecase
 
 import com.annict.type.StatusState
 import com.zelretch.aniiiiict.data.repository.AnnictRepository
-import timber.log.Timber
 import javax.inject.Inject
 
 class UpdateViewStateUseCase @Inject constructor(
     private val repository: AnnictRepository
 ) {
-    suspend operator fun invoke(workId: String, status: StatusState): Result<Unit> = runCatching {
-        val updateSuccess = repository.updateWorkViewStatus(workId, status)
-        if (!updateSuccess) {
-            Timber.w("ステータスの更新に失敗しました: workId=$workId")
-        }
-    }.fold(
-        onSuccess = { Result.success(Unit) },
-        onFailure = { e ->
-            Timber.e(e, "UpdateViewStateUseCase.invoke failed")
-            Result.failure(e)
-        }
-    )
+    suspend operator fun invoke(workId: String, status: StatusState): Result<Unit> =
+        repository.updateWorkViewStatus(workId, status)
 }

--- a/app/src/main/java/com/zelretch/aniiiiict/domain/usecase/WatchEpisodeUseCase.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/domain/usecase/WatchEpisodeUseCase.kt
@@ -21,13 +21,10 @@ class WatchEpisodeUseCase @Inject constructor(
         }
 
         // episodeId が空のときは記録をスキップ（ViewModel の既存呼び出しに対応）
-        val recordSuccess = if (episodeId.isBlank()) true else repository.createRecord(episodeId, workId)
-        if (!recordSuccess) error("Record creation failed")
-    }.fold(
-        onSuccess = { Result.success(Unit) },
-        onFailure = { e ->
-            Timber.e(e, "WatchEpisodeUseCase.invoke failed")
-            Result.failure(e)
+        if (episodeId.isNotBlank()) {
+            repository.createRecord(episodeId, workId).getOrThrow()
         }
-    )
+    }.onFailure { e ->
+        Timber.e(e, "WatchEpisodeUseCase.invoke failed")
+    }
 }

--- a/app/src/main/java/com/zelretch/aniiiiict/ui/common/components/episode/EpisodesList.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/ui/common/components/episode/EpisodesList.kt
@@ -1,8 +1,5 @@
 package com.zelretch.aniiiiict.ui.common.components.episode
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
@@ -13,22 +10,16 @@ import com.zelretch.aniiiiict.data.model.Program
 
 @Composable
 fun EpisodesList(programs: List<Program>, onRecordEpisode: (String) -> Unit, onMarkUpToAsWatched: (Int) -> Unit) {
-    AnimatedVisibility(
-        visible = true,
-        enter = fadeIn(),
-        exit = fadeOut()
+    LazyColumn(
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        LazyColumn(
-            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            items(items = programs, key = { it.id }) { program ->
-                EpisodeCard(
-                    program = program,
-                    onRecordEpisode = onRecordEpisode,
-                    onMarkUpToAsWatched = { onMarkUpToAsWatched(programs.indexOf(program)) }
-                )
-            }
+        items(items = programs, key = { it.id }) { program ->
+            EpisodeCard(
+                program = program,
+                onRecordEpisode = onRecordEpisode,
+                onMarkUpToAsWatched = { onMarkUpToAsWatched(programs.indexOf(program)) }
+            )
         }
     }
 }

--- a/app/src/main/java/com/zelretch/aniiiiict/ui/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/ui/history/HistoryViewModel.kt
@@ -5,6 +5,7 @@ import com.zelretch.aniiiiict.data.model.Record
 import com.zelretch.aniiiiict.domain.usecase.DeleteRecordUseCase
 import com.zelretch.aniiiiict.domain.usecase.LoadRecordsUseCase
 import com.zelretch.aniiiiict.domain.usecase.SearchRecordsUseCase
+import com.zelretch.aniiiiict.ui.base.ErrorMapper
 import com.zelretch.aniiiiict.ui.base.launchWithMinLoadingTime
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,10 +17,6 @@ import javax.inject.Inject
 
 /**
  * 視聴履歴画面のUI状態
- *
- * Note: ページネーション、検索、モーダル表示など複雑な状態管理があるため、
- * 現時点では従来のUiStateパターンを維持し、BaseViewModelのみ削除する。
- * 将来的にUiState<T>パターンへの完全移行を検討。
  */
 data class HistoryUiState(
     val records: List<Record> = emptyList(),
@@ -35,19 +32,13 @@ data class HistoryUiState(
 
 /**
  * 視聴履歴画面のViewModel
- *
- * Now in Android パターンへの移行:
- * - BaseViewModelを削除し、明示的なエラーハンドリング
- * - launchWithMinLoadingTimeで最小ローディング時間を保証
- * - ErrorMapperによるユーザー向けメッセージ変換
- *
- * Note: 将来的にUiState<T>パターンへの完全移行を検討 (see #176)
  */
 @HiltViewModel
 class HistoryViewModel @Inject constructor(
     private val loadRecordsUseCase: LoadRecordsUseCase,
     private val searchRecordsUseCase: SearchRecordsUseCase,
-    private val deleteRecordUseCase: DeleteRecordUseCase
+    private val deleteRecordUseCase: DeleteRecordUseCase,
+    private val errorMapper: ErrorMapper
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(HistoryUiState())
     val uiState: StateFlow<HistoryUiState> = _uiState.asStateFlow()
@@ -56,32 +47,31 @@ class HistoryViewModel @Inject constructor(
         loadRecords()
     }
 
-    /**
-     * レコードを読み込む
-     */
     fun loadRecords() {
         launchWithMinLoadingTime {
             _uiState.update { it.copy(isLoading = true, error = null) }
 
-            val result = loadRecordsUseCase()
-            val allRecords = result.records
-
-            _uiState.update { currentState ->
-                currentState.copy(
-                    allRecords = allRecords,
-                    records = searchRecordsUseCase(allRecords, currentState.searchQuery),
-                    hasNextPage = result.hasNextPage,
-                    endCursor = result.endCursor,
-                    isLoading = false,
-                    error = null
-                )
-            }
+            loadRecordsUseCase()
+                .onSuccess { result ->
+                    _uiState.update { currentState ->
+                        currentState.copy(
+                            allRecords = result.records,
+                            records = searchRecordsUseCase(result.records, currentState.searchQuery),
+                            hasNextPage = result.hasNextPage,
+                            endCursor = result.endCursor,
+                            isLoading = false,
+                            error = null
+                        )
+                    }
+                }
+                .onFailure { e ->
+                    val msg = errorMapper.toUserMessage(e, "HistoryViewModel.loadRecords")
+                    _uiState.update { it.copy(isLoading = false, error = msg) }
+                    Timber.e(e, "記録の読み込みに失敗: $msg")
+                }
         }
     }
 
-    /**
-     * 次のページを読み込む
-     */
     fun loadNextPage() {
         val currentState = _uiState.value
         if (currentState.isLoading || !currentState.hasNextPage || currentState.endCursor == null) {
@@ -91,24 +81,27 @@ class HistoryViewModel @Inject constructor(
         launchWithMinLoadingTime {
             _uiState.update { it.copy(isLoading = true) }
 
-            val result = loadRecordsUseCase(currentState.endCursor)
-
-            _uiState.update { state ->
-                val newAllRecords = state.allRecords + result.records
-                state.copy(
-                    allRecords = newAllRecords,
-                    records = searchRecordsUseCase(newAllRecords, state.searchQuery),
-                    hasNextPage = result.hasNextPage,
-                    endCursor = result.endCursor,
-                    isLoading = false
-                )
-            }
+            loadRecordsUseCase(currentState.endCursor)
+                .onSuccess { result ->
+                    _uiState.update { state ->
+                        val newAllRecords = state.allRecords + result.records
+                        state.copy(
+                            allRecords = newAllRecords,
+                            records = searchRecordsUseCase(newAllRecords, state.searchQuery),
+                            hasNextPage = result.hasNextPage,
+                            endCursor = result.endCursor,
+                            isLoading = false
+                        )
+                    }
+                }
+                .onFailure { e ->
+                    val msg = errorMapper.toUserMessage(e, "HistoryViewModel.loadNextPage")
+                    _uiState.update { it.copy(isLoading = false, error = msg) }
+                    Timber.e(e, "次ページの読み込みに失敗: $msg")
+                }
         }
     }
 
-    /**
-     * 検索クエリを更新する
-     */
     fun updateSearchQuery(query: String) {
         _uiState.update { currentState ->
             currentState.copy(
@@ -118,36 +111,31 @@ class HistoryViewModel @Inject constructor(
         }
     }
 
-    /**
-     * レコードを削除する
-     */
     fun deleteRecord(recordId: String) {
         launchWithMinLoadingTime {
             _uiState.update { it.copy(isLoading = true, error = null) }
 
-            val success = deleteRecordUseCase(recordId)
-
-            if (success) {
-                _uiState.update { currentState ->
-                    val newAllRecords = currentState.allRecords.filter { it.id != recordId }
-                    currentState.copy(
-                        allRecords = newAllRecords,
-                        records = searchRecordsUseCase(newAllRecords, currentState.searchQuery),
-                        isLoading = false,
-                        error = null
-                    )
+            deleteRecordUseCase(recordId)
+                .onSuccess {
+                    _uiState.update { currentState ->
+                        val newAllRecords = currentState.allRecords.filter { it.id != recordId }
+                        currentState.copy(
+                            allRecords = newAllRecords,
+                            records = searchRecordsUseCase(newAllRecords, currentState.searchQuery),
+                            isLoading = false,
+                            error = null
+                        )
+                    }
+                    Timber.i("レコードを削除しました: $recordId")
                 }
-                Timber.i("レコードを削除しました: $recordId")
-            } else {
-                _uiState.update { it.copy(isLoading = false, error = "記録の削除に失敗しました") }
-                Timber.w("レコード削除に失敗: $recordId")
-            }
+                .onFailure { e ->
+                    val msg = errorMapper.toUserMessage(e, "HistoryViewModel.deleteRecord")
+                    _uiState.update { it.copy(isLoading = false, error = msg) }
+                    Timber.e(e, "レコード削除に失敗: $msg")
+                }
         }
     }
 
-    /**
-     * レコード詳細を表示する
-     */
     fun showRecordDetail(record: Record) {
         _uiState.update {
             it.copy(
@@ -157,9 +145,6 @@ class HistoryViewModel @Inject constructor(
         }
     }
 
-    /**
-     * レコード詳細を非表示にする
-     */
     fun hideRecordDetail() {
         _uiState.update {
             it.copy(
@@ -169,9 +154,6 @@ class HistoryViewModel @Inject constructor(
         }
     }
 
-    /**
-     * エラーをクリアする
-     */
     fun clearError() {
         _uiState.update { it.copy(error = null) }
     }

--- a/app/src/main/java/com/zelretch/aniiiiict/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/ui/library/LibraryScreen.kt
@@ -131,7 +131,7 @@ private fun LibraryScreenContent(modifier: Modifier = Modifier, uiState: Library
                     modifier = Modifier.fillMaxSize(),
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    items(uiState.entries) { entry ->
+                    items(uiState.entries, key = { it.work.id }) { entry ->
                         LibraryEntryCard(
                             entry = entry,
                             onClick = { viewModel.showDetail(entry) }

--- a/app/src/main/java/com/zelretch/aniiiiict/ui/track/TrackViewModel.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/ui/track/TrackViewModel.kt
@@ -102,8 +102,8 @@ class TrackViewModel @Inject constructor(
         launchWithMinLoadingTime {
             _uiState.update { it.copy(isLoading = true, error = null) }
 
-            try {
-                loadProgramsUseCase().collect { programs ->
+            loadProgramsUseCase()
+                .onSuccess { programs ->
                     _uiState.update { currentState ->
                         val availableFilters = programFilterManager.extractAvailableFilters(programs)
                         val filteredPrograms = programFilterManager.filterPrograms(programs, currentState.filterState)
@@ -119,11 +119,11 @@ class TrackViewModel @Inject constructor(
                         )
                     }
                 }
-            } catch (e: Exception) {
-                val msg = errorMapper.toUserMessage(e, "TrackViewModel.loadingPrograms")
-                _uiState.update { it.copy(isLoading = false, error = msg) }
-                Timber.e(e, "プログラム一覧の読み込みに失敗: $msg")
-            }
+                .onFailure { e ->
+                    val msg = errorMapper.toUserMessage(e, "TrackViewModel.loadingPrograms")
+                    _uiState.update { it.copy(isLoading = false, error = msg) }
+                    Timber.e(e, "プログラム一覧の読み込みに失敗: $msg")
+                }
         }
     }
 

--- a/app/src/test/java/com/zelretch/aniiiiict/MainViewModelTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/MainViewModelTest.kt
@@ -2,6 +2,7 @@ package com.zelretch.aniiiiict
 
 import android.content.Context
 import androidx.browser.customtabs.CustomTabsIntent
+import com.zelretch.aniiiiict.domain.error.DomainError
 import com.zelretch.aniiiiict.domain.usecase.AnnictAuthUseCase
 import com.zelretch.aniiiiict.ui.base.CustomTabsIntentFactory
 import com.zelretch.aniiiiict.ui.base.ErrorMapper
@@ -123,7 +124,7 @@ class MainViewModelTest {
         @DisplayName("有効なコードで認証が成功する")
         fun withValidCode() {
             // Given
-            coEvery { authUseCase.handleAuthCallback(any()) } returns true
+            coEvery { authUseCase.handleAuthCallback(any()) } returns Result.success(Unit)
 
             // When
             viewModel.handleAuthCallback("valid_code")
@@ -140,7 +141,7 @@ class MainViewModelTest {
         @DisplayName("無効なコードでエラーが発生する")
         fun withInvalidCode() {
             // Given
-            coEvery { authUseCase.handleAuthCallback(any()) } returns false
+            coEvery { authUseCase.handleAuthCallback(any()) } returns Result.failure(RuntimeException("Auth failed"))
 
             // When
             viewModel.handleAuthCallback("invalid_code")
@@ -156,6 +157,10 @@ class MainViewModelTest {
         @Test
         @DisplayName("nullのコードでエラーが発生する")
         fun nullのコードでエラーが発生する() {
+            // Given
+            coEvery { authUseCase.handleAuthCallback(null) } returns
+                Result.failure(DomainError.AuthError.CallbackFailed())
+
             // When
             viewModel.handleAuthCallback(null)
             testDispatcher.scheduler.advanceUntilIdle()

--- a/app/src/test/java/com/zelretch/aniiiiict/domain/filter/ProgramFilterTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/domain/filter/ProgramFilterTest.kt
@@ -43,7 +43,7 @@ fun createProgramWithWork(
         mediaText = media,
         viewerStatusState = status ?: StatusState.NO_STATE
     )
-    return ProgramWithWork(listOf(program), program, work)
+    return ProgramWithWork(listOf(program), work)
 }
 
 @DisplayName("ProgramFilter")

--- a/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/AnnictAuthUseCaseTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/AnnictAuthUseCaseTest.kt
@@ -4,6 +4,7 @@ import com.zelretch.aniiiiict.data.repository.AnnictRepository
 import io.mockk.coEvery
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -80,13 +81,13 @@ class AnnictAuthUseCaseTest {
         fun withValidCode() = kotlinx.coroutines.test.runTest {
             // Given
             val code = "valid_code"
-            coEvery { repository.handleAuthCallback(code) } returns true
+            coEvery { repository.handleAuthCallback(code) } returns Result.success(Unit)
 
             // When
             val result = useCase.handleAuthCallback(code)
 
             // Then
-            assertEquals(true, result)
+            assertTrue(result.isSuccess)
         }
 
         @Test
@@ -96,7 +97,7 @@ class AnnictAuthUseCaseTest {
             val result = useCase.handleAuthCallback(null)
 
             // Then
-            assertEquals(false, result)
+            assertTrue(result.isFailure)
         }
 
         @Test
@@ -104,13 +105,13 @@ class AnnictAuthUseCaseTest {
         fun withInvalidCode() = kotlinx.coroutines.test.runTest {
             // Given
             val code = "invalid_code"
-            coEvery { repository.handleAuthCallback(code) } returns false
+            coEvery { repository.handleAuthCallback(code) } returns Result.failure(RuntimeException("Auth failed"))
 
             // When
             val result = useCase.handleAuthCallback(code)
 
             // Then
-            assertEquals(false, result)
+            assertTrue(result.isFailure)
         }
     }
 }

--- a/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/DeleteRecordUseCaseTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/DeleteRecordUseCaseTest.kt
@@ -4,7 +4,7 @@ import com.zelretch.aniiiiict.data.repository.AnnictRepository
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -27,29 +27,29 @@ class DeleteRecordUseCaseTest {
     inner class DeleteRecord {
 
         @Test
-        @DisplayName("成功時にtrueを返す")
+        @DisplayName("成功時にResult.successを返す")
         fun onSuccess() = runTest {
             // Given
-            coEvery { repository.deleteRecord("record1") } returns true
+            coEvery { repository.deleteRecord("record1") } returns Result.success(Unit)
 
             // When
             val result = useCase("record1")
 
             // Then
-            assertEquals(true, result)
+            assertTrue(result.isSuccess)
         }
 
         @Test
-        @DisplayName("失敗時にfalseを返す")
+        @DisplayName("失敗時にResult.failureを返す")
         fun onFailure() = runTest {
             // Given
-            coEvery { repository.deleteRecord("record2") } returns false
+            coEvery { repository.deleteRecord("record2") } returns Result.failure(RuntimeException("error"))
 
             // When
             val result = useCase("record2")
 
             // Then
-            assertEquals(false, result)
+            assertTrue(result.isFailure)
         }
     }
 }

--- a/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/GetAnimeDetailUseCaseTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/GetAnimeDetailUseCaseTest.kt
@@ -259,8 +259,7 @@ class GetAnimeDetailUseCaseTest {
 
         return ProgramWithWork(
             work = work,
-            programs = listOf(program),
-            firstProgram = program
+            programs = listOf(program)
         )
     }
 

--- a/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/LoadLibraryEntriesUseCaseTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/LoadLibraryEntriesUseCaseTest.kt
@@ -6,8 +6,6 @@ import com.zelretch.aniiiiict.data.model.Work
 import com.zelretch.aniiiiict.data.repository.AnnictRepository
 import io.mockk.coEvery
 import io.mockk.mockk
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -49,10 +47,10 @@ class LoadLibraryEntriesUseCaseTest {
                     statusState = StatusState.WATCHING
                 )
             )
-            coEvery { repository.getLibraryEntries(listOf(StatusState.WATCHING), null) } returns flowOf(fakeEntries)
+            coEvery { repository.getLibraryEntries(listOf(StatusState.WATCHING)) } returns Result.success(fakeEntries)
 
             // When
-            val result = useCase(listOf(StatusState.WATCHING)).first()
+            val result = useCase(listOf(StatusState.WATCHING)).getOrThrow()
 
             // Then
             assertEquals(2, result.size)
@@ -66,10 +64,10 @@ class LoadLibraryEntriesUseCaseTest {
         @DisplayName("空の結果を正しく処理できる")
         fun withEmptyResult() = runTest {
             // Given
-            coEvery { repository.getLibraryEntries(listOf(StatusState.WATCHING), null) } returns flowOf(emptyList())
+            coEvery { repository.getLibraryEntries(listOf(StatusState.WATCHING)) } returns Result.success(emptyList())
 
             // When
-            val result = useCase(listOf(StatusState.WATCHING)).first()
+            val result = useCase(listOf(StatusState.WATCHING)).getOrThrow()
 
             // Then
             assertEquals(0, result.size)
@@ -87,10 +85,10 @@ class LoadLibraryEntriesUseCaseTest {
                     statusState = StatusState.WATCHING
                 )
             )
-            coEvery { repository.getLibraryEntries(listOf(StatusState.WATCHING), null) } returns flowOf(fakeEntries)
+            coEvery { repository.getLibraryEntries(listOf(StatusState.WATCHING)) } returns Result.success(fakeEntries)
 
             // When
-            val result = useCase().first()
+            val result = useCase().getOrThrow()
 
             // Then
             assertEquals(1, result.size)

--- a/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/LoadProgramsUseCaseTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/LoadProgramsUseCaseTest.kt
@@ -8,8 +8,6 @@ import com.zelretch.aniiiiict.data.repository.AnnictRepository
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -40,10 +38,10 @@ class LoadProgramsUseCaseTest {
         fun groupedAndSorted() = runTest {
             // Given
             val mockPrograms = TestHelper.createMockPrograms()
-            coEvery { repository.getRawProgramsData() } returns flow { emit(mockPrograms) }
+            coEvery { repository.getRawProgramsData() } returns Result.success(mockPrograms)
 
             // When
-            val result = useCase().first()
+            val result = useCase().getOrThrow()
 
             // Then
             assertEquals(2, result.size) // 2つの異なる作品
@@ -71,10 +69,10 @@ class LoadProgramsUseCaseTest {
         fun sortedByEpisodeNumber() = runTest {
             // Given
             val nodes = TestHelper.createMockEpisodesForSameAnime()
-            coEvery { repository.getRawProgramsData() } returns flow { emit(nodes) }
+            coEvery { repository.getRawProgramsData() } returns Result.success(nodes)
 
             // When
-            val result = useCase().first()
+            val result = useCase().getOrThrow()
 
             // Then
             assertEquals(1, result.size) // 1つの作品
@@ -94,10 +92,10 @@ class LoadProgramsUseCaseTest {
         @DisplayName("空のデータが返された場合空のリストが返される")
         fun withEmptyData() = runTest {
             // Given
-            coEvery { repository.getRawProgramsData() } returns flow { emit(emptyList()) }
+            coEvery { repository.getRawProgramsData() } returns Result.success(emptyList())
 
             // When
-            val result = useCase().first()
+            val result = useCase().getOrThrow()
 
             // Then
             assertEquals(0, result.size)

--- a/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/LoadRecordsUseCaseTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/LoadRecordsUseCaseTest.kt
@@ -61,10 +61,10 @@ class LoadRecordsUseCaseTest {
                 hasNextPage = true,
                 endCursor = "CURSOR123"
             )
-            coEvery { repository.getRecords(null) } returns paginated
+            coEvery { repository.getRecords(null) } returns Result.success(paginated)
 
             // When
-            val result = useCase()
+            val result = useCase().getOrThrow()
 
             // Then
             assertEquals(fakeRecords, result.records)
@@ -81,10 +81,10 @@ class LoadRecordsUseCaseTest {
                 hasNextPage = false,
                 endCursor = null
             )
-            coEvery { repository.getRecords(null) } returns paginated
+            coEvery { repository.getRecords(null) } returns Result.success(paginated)
 
             // When
-            val result = useCase()
+            val result = useCase().getOrThrow()
 
             // Then
             assertEquals(emptyList<Record>(), result.records)

--- a/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/UpdateViewStateUseCaseTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/UpdateViewStateUseCaseTest.kt
@@ -31,7 +31,7 @@ class UpdateViewStateUseCaseTest {
         @DisplayName("Repository成功時にResult.successを返す")
         fun onRepositorySuccess() = runTest {
             // Given
-            coEvery { repository.updateWorkViewStatus(any(), any()) } returns true
+            coEvery { repository.updateWorkViewStatus(any(), any()) } returns Result.success(Unit)
 
             // When
             val result = useCase("w1", StatusState.WATCHING)
@@ -41,16 +41,16 @@ class UpdateViewStateUseCaseTest {
         }
 
         @Test
-        @DisplayName("Repository失敗時でもResult.successを返す（警告ログ出力）")
+        @DisplayName("Repository失敗時にResult.failureを返す")
         fun onRepositoryFailure() = runTest {
             // Given
-            coEvery { repository.updateWorkViewStatus(any(), any()) } returns false
+            coEvery { repository.updateWorkViewStatus(any(), any()) } returns Result.failure(RuntimeException("error"))
 
             // When
             val result = useCase("w1", StatusState.WATCHING)
 
             // Then
-            assertTrue(result.isSuccess)
+            assertTrue(result.isFailure)
         }
     }
 }

--- a/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/WatchEpisodeUseCaseTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/WatchEpisodeUseCaseTest.kt
@@ -33,7 +33,7 @@ class WatchEpisodeUseCaseTest {
         @DisplayName("記録成功時にResult.successを返す")
         fun onSuccess() = runTest {
             // Given
-            coEvery { repository.createRecord(any(), any()) } returns true
+            coEvery { repository.createRecord(any(), any()) } returns Result.success(Unit)
             coEvery { updateViewStateUseCase(any(), any()) } returns Result.success(Unit)
 
             // When
@@ -47,7 +47,7 @@ class WatchEpisodeUseCaseTest {
         @DisplayName("記録失敗時にResult.failureを返す")
         fun onFailure() = runTest {
             // Given
-            coEvery { repository.createRecord(any(), any()) } returns false
+            coEvery { repository.createRecord(any(), any()) } returns Result.failure(RuntimeException("error"))
 
             // When
             val result = useCase("ep1", "w1", StatusState.WANNA_WATCH, true)

--- a/app/src/test/java/com/zelretch/aniiiiict/integration/AnimeDetailIntegrationTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/integration/AnimeDetailIntegrationTest.kt
@@ -198,8 +198,7 @@ class AnimeDetailIntegrationTest {
 
         return ProgramWithWork(
             work = work,
-            programs = listOf(program),
-            firstProgram = program
+            programs = listOf(program)
         )
     }
 

--- a/app/src/test/java/com/zelretch/aniiiiict/integration/BulkRecordingFinaleJudgmentIntegrationTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/integration/BulkRecordingFinaleJudgmentIntegrationTest.kt
@@ -67,7 +67,7 @@ class BulkRecordingFinaleJudgmentIntegrationTest {
                 mainPicture = null
             )
 
-            coEvery { annictRepository.createRecord(any(), any()) } returns true
+            coEvery { annictRepository.createRecord(any(), any()) } returns Result.success(Unit)
             coEvery { updateViewStateUseCase(any(), any()) } returns Result.success(Unit)
             coEvery { malRepository.getAnimeDetail(malAnimeId) } returns Result.success(media)
 
@@ -108,7 +108,7 @@ class BulkRecordingFinaleJudgmentIntegrationTest {
                 mainPicture = null
             )
 
-            coEvery { annictRepository.createRecord(any(), any()) } returns true
+            coEvery { annictRepository.createRecord(any(), any()) } returns Result.success(Unit)
             coEvery { updateViewStateUseCase(any(), any()) } returns Result.success(Unit)
             coEvery { malRepository.getAnimeDetail(malAnimeId) } returns Result.success(media)
 
@@ -139,7 +139,7 @@ class BulkRecordingFinaleJudgmentIntegrationTest {
             val episodeIds = listOf("ep1", "ep2")
             val workId = "work1"
 
-            coEvery { annictRepository.createRecord(any(), any()) } returns true
+            coEvery { annictRepository.createRecord(any(), any()) } returns Result.success(Unit)
             coEvery { updateViewStateUseCase(any(), any()) } returns Result.success(Unit)
 
             // Act

--- a/app/src/test/java/com/zelretch/aniiiiict/integration/LibraryIntegrationTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/integration/LibraryIntegrationTest.kt
@@ -7,8 +7,6 @@ import com.zelretch.aniiiiict.data.repository.AnnictRepository
 import com.zelretch.aniiiiict.domain.usecase.LoadLibraryEntriesUseCase
 import io.mockk.coEvery
 import io.mockk.mockk
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -44,10 +42,10 @@ class LibraryIntegrationTest {
                 createLibraryEntry("entry2", "work2", "終物語"),
                 createLibraryEntry("entry3", "work3", "SPY×FAMILY")
             )
-            coEvery { repository.getLibraryEntries(listOf(StatusState.WATCHING), null) } returns flowOf(entries)
+            coEvery { repository.getLibraryEntries(listOf(StatusState.WATCHING), null) } returns Result.success(entries)
 
             // When
-            val result = useCase(listOf(StatusState.WATCHING)).first()
+            val result = useCase(listOf(StatusState.WATCHING)).getOrThrow()
 
             // Then
             assertEquals(3, result.size)
@@ -60,10 +58,11 @@ class LibraryIntegrationTest {
         @DisplayName("空のリストが返される場合正しく処理される")
         fun handlesEmptyList() = runTest {
             // Given
-            coEvery { repository.getLibraryEntries(listOf(StatusState.WATCHING), null) } returns flowOf(emptyList())
+            coEvery { repository.getLibraryEntries(listOf(StatusState.WATCHING), null) } returns
+                Result.success(emptyList())
 
             // When
-            val result = useCase(listOf(StatusState.WATCHING)).first()
+            val result = useCase(listOf(StatusState.WATCHING)).getOrThrow()
 
             // Then
             assertEquals(0, result.size)
@@ -78,10 +77,10 @@ class LibraryIntegrationTest {
                 createLibraryEntry("entry1", "work1", "Work 1"),
                 createLibraryEntry("entry2", "work2", "Work 2")
             )
-            coEvery { repository.getLibraryEntries(states, null) } returns flowOf(entries)
+            coEvery { repository.getLibraryEntries(states, null) } returns Result.success(entries)
 
             // When
-            val result = useCase(states).first()
+            val result = useCase(states).getOrThrow()
 
             // Then
             assertEquals(2, result.size)

--- a/app/src/test/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailViewModelTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailViewModelTest.kt
@@ -142,8 +142,7 @@ class AnimeDetailViewModelTest {
 
         return ProgramWithWork(
             work = work,
-            programs = listOf(program),
-            firstProgram = program
+            programs = listOf(program)
         )
     }
 

--- a/app/src/test/java/com/zelretch/aniiiiict/ui/library/LibraryViewModelTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/ui/library/LibraryViewModelTest.kt
@@ -12,7 +12,6 @@ import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -57,8 +56,8 @@ class LibraryViewModelTest {
         @DisplayName("loadLibraryEntriesが呼ばれUIステートが初期値で更新される")
         fun loadLibraryEntriesが呼ばれUIステートが初期値で更新される() = runTest(dispatcher) {
             // Given
-            coEvery { loadProgramsUseCase() } returns flowOf(emptyList())
-            coEvery { loadLibraryEntriesUseCase(listOf(StatusState.WATCHING)) } returns flowOf(emptyList())
+            coEvery { loadProgramsUseCase() } returns Result.success(emptyList())
+            coEvery { loadLibraryEntriesUseCase(listOf(StatusState.WATCHING)) } returns Result.success(emptyList())
 
             // When
             val viewModel = LibraryViewModel(loadLibraryEntriesUseCase, loadProgramsUseCase, errorMapper)
@@ -90,8 +89,8 @@ class LibraryViewModelTest {
                     statusState = StatusState.WATCHING
                 )
             )
-            coEvery { loadProgramsUseCase() } returns flowOf(emptyList())
-            coEvery { loadLibraryEntriesUseCase(listOf(StatusState.WATCHING)) } returns flowOf(fakeEntries)
+            coEvery { loadProgramsUseCase() } returns Result.success(emptyList())
+            coEvery { loadLibraryEntriesUseCase(listOf(StatusState.WATCHING)) } returns Result.success(fakeEntries)
 
             // When
             val viewModel = LibraryViewModel(loadLibraryEntriesUseCase, loadProgramsUseCase, errorMapper)
@@ -130,10 +129,10 @@ class LibraryViewModelTest {
                     statusState = StatusState.WATCHING
                 )
             )
-            coEvery { loadProgramsUseCase() } returns flowOf(emptyList())
+            coEvery { loadProgramsUseCase() } returns Result.success(emptyList())
             coEvery { loadLibraryEntriesUseCase(listOf(StatusState.WATCHING)) } returnsMany listOf(
-                flowOf(initialEntries),
-                flowOf(refreshedEntries)
+                Result.success(initialEntries),
+                Result.success(refreshedEntries)
             )
 
             val viewModel = LibraryViewModel(loadLibraryEntriesUseCase, loadProgramsUseCase, errorMapper)
@@ -166,8 +165,8 @@ class LibraryViewModelTest {
                     statusState = StatusState.WATCHING
                 )
             )
-            coEvery { loadProgramsUseCase() } returns flowOf(emptyList())
-            coEvery { loadLibraryEntriesUseCase(listOf(StatusState.WATCHING)) } returns flowOf(fakeEntries)
+            coEvery { loadProgramsUseCase() } returns Result.success(emptyList())
+            coEvery { loadLibraryEntriesUseCase(listOf(StatusState.WATCHING)) } returns Result.success(fakeEntries)
 
             val viewModel = LibraryViewModel(loadLibraryEntriesUseCase, loadProgramsUseCase, errorMapper)
             val initialState = viewModel.uiState.first { !it.isLoading }
@@ -185,8 +184,8 @@ class LibraryViewModelTest {
         @DisplayName("フィルター表示が切り替わる")
         fun toggleFilterVisibility() = runTest(dispatcher) {
             // Given
-            coEvery { loadProgramsUseCase() } returns flowOf(emptyList())
-            coEvery { loadLibraryEntriesUseCase(listOf(StatusState.WATCHING)) } returns flowOf(emptyList())
+            coEvery { loadProgramsUseCase() } returns Result.success(emptyList())
+            coEvery { loadLibraryEntriesUseCase(listOf(StatusState.WATCHING)) } returns Result.success(emptyList())
 
             val viewModel = LibraryViewModel(loadLibraryEntriesUseCase, loadProgramsUseCase, errorMapper)
             val initialState = viewModel.uiState.first { !it.isLoading }
@@ -210,10 +209,8 @@ class LibraryViewModelTest {
         fun showsErrorMessage() = runTest(dispatcher) {
             // Given
             val exception = RuntimeException("Network error")
-            coEvery { loadProgramsUseCase() } returns flowOf(emptyList())
-            coEvery { loadLibraryEntriesUseCase(listOf(StatusState.WATCHING)) } returns kotlinx.coroutines.flow.flow {
-                throw exception
-            }
+            coEvery { loadProgramsUseCase() } returns Result.success(emptyList())
+            coEvery { loadLibraryEntriesUseCase(listOf(StatusState.WATCHING)) } returns Result.failure(exception)
             every { errorMapper.toUserMessage(exception) } returns "ネットワークエラーが発生しました"
 
             // When

--- a/app/src/test/java/com/zelretch/aniiiiict/ui/track/BroadcastEpisodeModalViewModelTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/ui/track/BroadcastEpisodeModalViewModelTest.kt
@@ -83,7 +83,6 @@ class BroadcastEpisodeModalViewModelTest {
             }
             val programWithWork = ProgramWithWork(
                 programs = listOf(program),
-                firstProgram = program,
                 work = work
             )
 
@@ -143,7 +142,6 @@ class BroadcastEpisodeModalViewModelTest {
             }
             val programWithWork = ProgramWithWork(
                 programs = listOf(program),
-                firstProgram = program,
                 work = work
             )
 
@@ -185,7 +183,6 @@ class BroadcastEpisodeModalViewModelTest {
             }
             val programWithWork = ProgramWithWork(
                 programs = listOf(program),
-                firstProgram = program,
                 work = work
             )
 

--- a/app/src/test/java/com/zelretch/aniiiiict/ui/track/TrackViewModelTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/ui/track/TrackViewModelTest.kt
@@ -27,8 +27,6 @@ import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -75,7 +73,7 @@ class TrackViewModelTest {
         mockk<Context>(relaxed = true)
 
         // デフォルトで空リストを返すflow
-        coEvery { loadProgramsUseCase.invoke() } returns flowOf(emptyList())
+        coEvery { loadProgramsUseCase.invoke() } returns Result.success(emptyList())
         every { filterProgramsUseCase.invoke(any(), any()) } answers { firstArg() }
         every { filterProgramsUseCase.extractAvailableFilters(any()) } returns AvailableFilters(
             emptyList(),
@@ -119,7 +117,7 @@ class TrackViewModelTest {
         fun onSuccess() = runTest(dispatcher) {
             // Given
             val fakePrograms = listOf<ProgramWithWork>(mockk(relaxed = true))
-            coEvery { loadProgramsUseCase.invoke() } returns flowOf(fakePrograms)
+            coEvery { loadProgramsUseCase.invoke() } returns Result.success(fakePrograms)
             every { filterProgramsUseCase.invoke(any(), any()) } returns fakePrograms
             every { filterProgramsUseCase.extractAvailableFilters(any()) } returns AvailableFilters(
                 emptyList(),
@@ -144,9 +142,7 @@ class TrackViewModelTest {
         fun onException() = runTest(dispatcher) {
             // Given
             every { errorMapper.toUserMessage(any(), any()) } returns "処理中にエラーが発生しました"
-            coEvery { loadProgramsUseCase.invoke() } returns flow {
-                throw LoadProgramsException("error")
-            }
+            coEvery { loadProgramsUseCase.invoke() } returns Result.failure(LoadProgramsException("error"))
 
             // When
             filterStateFlow.value = filterStateFlow.value.copy(selectedMedia = setOf("dummy-error"))
@@ -170,7 +166,7 @@ class TrackViewModelTest {
             val workId = "work-finale-no"
             val episodeId = "ep-final-12-no"
             val fakePrograms = createTestProgram(workId, episodeId)
-            coEvery { loadProgramsUseCase() } returns flowOf(listOf(fakePrograms))
+            coEvery { loadProgramsUseCase() } returns Result.success(listOf(fakePrograms))
             coEvery { watchEpisodeUseCase.invoke(any(), any(), any()) } returns Result.success(Unit)
             coEvery { judgeFinaleUseCase.invoke(any(), any()) } returns JudgeFinaleResult(
                 com.zelretch.aniiiiict.domain.usecase.FinaleState.FINALE_CONFIRMED
@@ -204,7 +200,7 @@ class TrackViewModelTest {
             val episodeId = "ep5"
             val fakePrograms = createTestProgram(workId, episodeId)
 
-            coEvery { loadProgramsUseCase() } returns flowOf(listOf(fakePrograms))
+            coEvery { loadProgramsUseCase() } returns Result.success(listOf(fakePrograms))
             coEvery { watchEpisodeUseCase.invoke(any(), any(), any()) } returns Result.success(Unit)
             coEvery { judgeFinaleUseCase.invoke(any(), any()) } returns JudgeFinaleResult(
                 com.zelretch.aniiiiict.domain.usecase.FinaleState.UNKNOWN
@@ -234,7 +230,7 @@ class TrackViewModelTest {
             val episodeId = "ep1"
             val fakePrograms = createTestProgram(workId, episodeId)
 
-            coEvery { loadProgramsUseCase() } returns flowOf(listOf(fakePrograms))
+            coEvery { loadProgramsUseCase() } returns Result.success(listOf(fakePrograms))
             coEvery { watchEpisodeUseCase.invoke(any(), any(), any()) } returns Result.success(Unit)
             coEvery { judgeFinaleUseCase.invoke(any(), any()) } returns JudgeFinaleResult(
                 com.zelretch.aniiiiict.domain.usecase.FinaleState.UNKNOWN
@@ -284,7 +280,6 @@ private fun createTestProgram(workId: String, episodeId: String): ProgramWithWor
     )
     return ProgramWithWork(
         programs = listOf(program),
-        firstProgram = program,
         work = work
     )
 }


### PR DESCRIPTION
## Summary
- Repository層の全メソッドを`Result<T>`に統一（`Boolean`/`Flow`/raw型の混在を解消）
- `getRawProgramsData()`と`getLibraryEntries()`からFlowを除去（単発emit、リアクティブ不要）
- `DomainError`をRepository→UseCase→ViewModelで一貫して伝播
- ViewModelのエラーハンドリングを`Result.onSuccess/onFailure` + `ErrorMapper`に統一
- 冗長な`RecordsResult`を削除し`PaginatedRecords`を直接使用
- `ProgramWithWork.firstProgram`をcomputed propertyに変更、`var`→`val`
- `EpisodesList`の無意味な`AnimatedVisibility(visible=true)`を削除
- `LibraryScreen`のLazyColumnに`key`パラメータ追加
- MockKが`kotlin.Result`(inline class)を扱えない問題を`FakeAnnictRepository`で解決
- 全Unit/Instrumentationテストを新シグネチャに対応

## Test plan
- [x] `./gradlew testDebugUnitTest` 全成功
- [x] `./gradlew connectedDebugAndroidTest` 92/92テスト全成功

🤖 Generated with [Claude Code](https://claude.ai/claude-code)