### PR TITLE
feat: ライブラリの全ステータス取得とページネーション実装 (Issue #209)

### DIFF
--- a/app/src/main/java/com/zelretch/aniiiiict/data/repository/AnnictRepositoryImpl.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/data/repository/AnnictRepositoryImpl.kt
@@ -218,27 +218,36 @@ class AnnictRepositoryImpl @Inject constructor(
         executeApiRequest("getLibraryEntries") {
             Timber.i("ライブラリエントリー一覧の取得を開始: states=$states")
 
-            val query = com.annict.ViewerLibraryEntriesQuery(
-                states = Optional.present(states),
-                after = Optional.presentIfNotNull(after)
-            )
-            val response = annictApolloClient.executeQuery(
-                operation = query,
-                context = "AnnictRepositoryImpl.getLibraryEntries"
-            )
+            val allEntries = mutableListOf<LibraryEntry>()
+            var cursor: String? = after
 
-            Timber.i("GraphQLのレスポンス: ${response.data != null}")
+            do {
+                val query = com.annict.ViewerLibraryEntriesQuery(
+                    states = Optional.present(states),
+                    after = Optional.presentIfNotNull(cursor)
+                )
+                val response = annictApolloClient.executeQuery(
+                    operation = query,
+                    context = "AnnictRepositoryImpl.getLibraryEntries"
+                )
 
-            if (response.hasErrors()) {
-                Timber.e("GraphQLエラー: ${response.errors}")
-                throw DomainError.ApiError.GraphQLError("Library entries query failed: ${response.errors}")
-            }
+                if (response.hasErrors()) {
+                    Timber.e("GraphQLエラー: ${response.errors}")
+                    throw DomainError.ApiError.GraphQLError("Library entries query failed: ${response.errors}")
+                }
 
-            val nodes = response.data?.viewer?.libraryEntries?.nodes?.filterNotNull() ?: emptyList()
-            val entries = nodes.mapNotNull { node -> mapToLibraryEntry(node) }
+                val libraryEntries = response.data?.viewer?.libraryEntries
+                val nodes = libraryEntries?.nodes?.filterNotNull() ?: emptyList()
+                allEntries.addAll(nodes.mapNotNull { mapToLibraryEntry(it) })
 
-            Timber.i("ライブラリエントリー一覧を取得しました: ${entries.size}件")
-            entries
+                val pageInfo = libraryEntries?.pageInfo
+                cursor = if (pageInfo?.hasNextPage == true) pageInfo.endCursor else null
+
+                Timber.i("ページ取得: ${nodes.size}件, hasNextPage=${pageInfo?.hasNextPage}")
+            } while (cursor != null)
+
+            Timber.i("ライブラリエントリー全件取得完了: ${allEntries.size}件")
+            allEntries
         }
 
     private fun mapToLibraryEntry(node: com.annict.ViewerLibraryEntriesQuery.Node): LibraryEntry? {

--- a/app/src/main/java/com/zelretch/aniiiiict/domain/usecase/LoadLibraryEntriesUseCase.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/domain/usecase/LoadLibraryEntriesUseCase.kt
@@ -5,9 +5,17 @@ import com.zelretch.aniiiiict.data.model.LibraryEntry
 import com.zelretch.aniiiiict.data.repository.AnnictRepository
 import javax.inject.Inject
 
+private val ALL_STATUSES = listOf(
+    StatusState.WATCHING,
+    StatusState.WANNA_WATCH,
+    StatusState.WATCHED,
+    StatusState.ON_HOLD,
+    StatusState.STOP_WATCHING
+)
+
 class LoadLibraryEntriesUseCase @Inject constructor(
     private val repository: AnnictRepository
 ) {
-    suspend operator fun invoke(states: List<StatusState> = listOf(StatusState.WATCHING)): Result<List<LibraryEntry>> =
+    suspend operator fun invoke(states: List<StatusState> = ALL_STATUSES): Result<List<LibraryEntry>> =
         repository.getLibraryEntries(states)
 }

--- a/app/src/main/java/com/zelretch/aniiiiict/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/ui/library/LibraryViewModel.kt
@@ -2,7 +2,6 @@ package com.zelretch.aniiiiict.ui.library
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.annict.type.StatusState
 import com.zelretch.aniiiiict.data.model.LibraryEntry
 import com.zelretch.aniiiiict.domain.filter.FilterState
 import com.zelretch.aniiiiict.domain.usecase.LoadLibraryEntriesUseCase
@@ -69,7 +68,7 @@ class LibraryViewModel @Inject constructor(
                 }
 
             // ライブラリエントリーを読み込む
-            loadLibraryEntriesUseCase(listOf(StatusState.WATCHING))
+            loadLibraryEntriesUseCase()
                 .onSuccess { entries ->
                     Timber.i("ライブラリエントリーを取得: ${entries.size}件")
                     val availableMedia = entries.mapNotNull { it.work.media }.distinct().sorted()

--- a/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/LoadLibraryEntriesUseCaseTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/LoadLibraryEntriesUseCaseTest.kt
@@ -74,9 +74,16 @@ class LoadLibraryEntriesUseCaseTest {
         }
 
         @Test
-        @DisplayName("デフォルトでWATCHINGステートを使用する")
-        fun usesWatchingStateByDefault() = runTest {
+        @DisplayName("デフォルトで全ステータスを使用する")
+        fun usesAllStatusesByDefault() = runTest {
             // Given
+            val allStatuses = listOf(
+                StatusState.WATCHING,
+                StatusState.WANNA_WATCH,
+                StatusState.WATCHED,
+                StatusState.ON_HOLD,
+                StatusState.STOP_WATCHING
+            )
             val fakeEntries = listOf(
                 LibraryEntry(
                     id = "entry1",
@@ -85,7 +92,7 @@ class LoadLibraryEntriesUseCaseTest {
                     statusState = StatusState.WATCHING
                 )
             )
-            coEvery { repository.getLibraryEntries(listOf(StatusState.WATCHING)) } returns Result.success(fakeEntries)
+            coEvery { repository.getLibraryEntries(allStatuses) } returns Result.success(fakeEntries)
 
             // When
             val result = useCase().getOrThrow()

--- a/app/src/test/java/com/zelretch/aniiiiict/ui/library/LibraryViewModelTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/ui/library/LibraryViewModelTest.kt
@@ -57,7 +57,7 @@ class LibraryViewModelTest {
         fun loadLibraryEntriesが呼ばれUIステートが初期値で更新される() = runTest(dispatcher) {
             // Given
             coEvery { loadProgramsUseCase() } returns Result.success(emptyList())
-            coEvery { loadLibraryEntriesUseCase(listOf(StatusState.WATCHING)) } returns Result.success(emptyList())
+            coEvery { loadLibraryEntriesUseCase(any()) } returns Result.success(emptyList())
 
             // When
             val viewModel = LibraryViewModel(loadLibraryEntriesUseCase, loadProgramsUseCase, errorMapper)
@@ -90,7 +90,7 @@ class LibraryViewModelTest {
                 )
             )
             coEvery { loadProgramsUseCase() } returns Result.success(emptyList())
-            coEvery { loadLibraryEntriesUseCase(listOf(StatusState.WATCHING)) } returns Result.success(fakeEntries)
+            coEvery { loadLibraryEntriesUseCase(any()) } returns Result.success(fakeEntries)
 
             // When
             val viewModel = LibraryViewModel(loadLibraryEntriesUseCase, loadProgramsUseCase, errorMapper)
@@ -130,7 +130,7 @@ class LibraryViewModelTest {
                 )
             )
             coEvery { loadProgramsUseCase() } returns Result.success(emptyList())
-            coEvery { loadLibraryEntriesUseCase(listOf(StatusState.WATCHING)) } returnsMany listOf(
+            coEvery { loadLibraryEntriesUseCase(any()) } returnsMany listOf(
                 Result.success(initialEntries),
                 Result.success(refreshedEntries)
             )
@@ -166,7 +166,7 @@ class LibraryViewModelTest {
                 )
             )
             coEvery { loadProgramsUseCase() } returns Result.success(emptyList())
-            coEvery { loadLibraryEntriesUseCase(listOf(StatusState.WATCHING)) } returns Result.success(fakeEntries)
+            coEvery { loadLibraryEntriesUseCase(any()) } returns Result.success(fakeEntries)
 
             val viewModel = LibraryViewModel(loadLibraryEntriesUseCase, loadProgramsUseCase, errorMapper)
             val initialState = viewModel.uiState.first { !it.isLoading }
@@ -185,7 +185,7 @@ class LibraryViewModelTest {
         fun toggleFilterVisibility() = runTest(dispatcher) {
             // Given
             coEvery { loadProgramsUseCase() } returns Result.success(emptyList())
-            coEvery { loadLibraryEntriesUseCase(listOf(StatusState.WATCHING)) } returns Result.success(emptyList())
+            coEvery { loadLibraryEntriesUseCase(any()) } returns Result.success(emptyList())
 
             val viewModel = LibraryViewModel(loadLibraryEntriesUseCase, loadProgramsUseCase, errorMapper)
             val initialState = viewModel.uiState.first { !it.isLoading }
@@ -210,7 +210,7 @@ class LibraryViewModelTest {
             // Given
             val exception = RuntimeException("Network error")
             coEvery { loadProgramsUseCase() } returns Result.success(emptyList())
-            coEvery { loadLibraryEntriesUseCase(listOf(StatusState.WATCHING)) } returns Result.failure(exception)
+            coEvery { loadLibraryEntriesUseCase(any()) } returns Result.failure(exception)
             every { errorMapper.toUserMessage(exception) } returns "ネットワークエラーが発生しました"
 
             // When
@@ -253,7 +253,7 @@ class LibraryViewModelTest {
                 )
             )
             coEvery { loadProgramsUseCase() } returns Result.success(emptyList())
-            coEvery { loadLibraryEntriesUseCase(listOf(StatusState.WATCHING)) } returns Result.success(fakeEntries)
+            coEvery { loadLibraryEntriesUseCase(any()) } returns Result.success(fakeEntries)
 
             // When
             val viewModel = LibraryViewModel(loadLibraryEntriesUseCase, loadProgramsUseCase, errorMapper)
@@ -276,7 +276,7 @@ class LibraryViewModelTest {
                 )
             )
             coEvery { loadProgramsUseCase() } returns Result.success(emptyList())
-            coEvery { loadLibraryEntriesUseCase(listOf(StatusState.WATCHING)) } returns Result.success(fakeEntries)
+            coEvery { loadLibraryEntriesUseCase(any()) } returns Result.success(fakeEntries)
 
             val viewModel = LibraryViewModel(loadLibraryEntriesUseCase, loadProgramsUseCase, errorMapper)
             viewModel.uiState.first { !it.isLoading }
@@ -302,7 +302,7 @@ class LibraryViewModelTest {
                 )
             )
             coEvery { loadProgramsUseCase() } returns Result.success(emptyList())
-            coEvery { loadLibraryEntriesUseCase(listOf(StatusState.WATCHING)) } returns Result.success(fakeEntries)
+            coEvery { loadLibraryEntriesUseCase(any()) } returns Result.success(fakeEntries)
 
             val viewModel = LibraryViewModel(loadLibraryEntriesUseCase, loadProgramsUseCase, errorMapper)
             viewModel.uiState.first { !it.isLoading }
@@ -336,7 +336,7 @@ class LibraryViewModelTest {
                 )
             )
             coEvery { loadProgramsUseCase() } returns Result.success(emptyList())
-            coEvery { loadLibraryEntriesUseCase(listOf(StatusState.WATCHING)) } returns Result.success(fakeEntries)
+            coEvery { loadLibraryEntriesUseCase(any()) } returns Result.success(fakeEntries)
 
             val viewModel = LibraryViewModel(loadLibraryEntriesUseCase, loadProgramsUseCase, errorMapper)
             viewModel.uiState.first { !it.isLoading }
@@ -369,7 +369,7 @@ class LibraryViewModelTest {
                 )
             )
             coEvery { loadProgramsUseCase() } returns Result.success(emptyList())
-            coEvery { loadLibraryEntriesUseCase(listOf(StatusState.WATCHING)) } returns Result.success(fakeEntries)
+            coEvery { loadLibraryEntriesUseCase(any()) } returns Result.success(fakeEntries)
 
             // When
             val viewModel = LibraryViewModel(loadLibraryEntriesUseCase, loadProgramsUseCase, errorMapper)


### PR DESCRIPTION
## Summary

- `AnnictRepositoryImpl`: `getLibraryEntries()` にページネーションループを追加し、全ページを取得するよう変更
- `LoadLibraryEntriesUseCase`: デフォルト引数を `WATCHING` のみから全5ステータス（`WATCHING` / `WANNA_WATCH` / `WATCHED` / `ON_HOLD` / `STOP_WATCHING`）に変更
- `LibraryViewModel`: デフォルト引数を使用するよう変更し、不要な `StatusState` インポートを削除
- テスト修正: デフォルトステータスのテストケースと ViewModel のモック引数を更新

## Test plan

- [x] `./gradlew testDebugUnitTest` が全テスト通過することを確認
- [ ] 実機/エミュレータでライブラリ画面を開き、全ステータス（視聴中・見たい・見た・中断・視聴停止）のエントリーが表示されることを確認

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)