### PR TITLE
fix: NetworkExceptionをDomainErrorに正しくマッピングする (Issue #237)

### DIFF
--- a/app/src/main/java/com/zelretch/aniiiiict/data/repository/AnnictRepositoryImpl.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/data/repository/AnnictRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.apollographql.apollo.exception.ApolloException
 import com.zelretch.aniiiiict.data.api.AnnictApolloClient
 import com.zelretch.aniiiiict.data.auth.AnnictAuthManager
 import com.zelretch.aniiiiict.data.auth.TokenManager
+import com.zelretch.aniiiiict.data.exception.NetworkException
 import com.zelretch.aniiiiict.data.model.Episode
 import com.zelretch.aniiiiict.data.model.LibraryEntriesPage
 import com.zelretch.aniiiiict.data.model.LibraryEntry
@@ -298,9 +299,18 @@ class AnnictRepositoryImpl @Inject constructor(
         } catch (e: DomainError) {
             Timber.e(e, "[$operation] Domain error")
             Result.failure(e)
+        } catch (e: NetworkException) {
+            Timber.e(e, "[$operation] Network error")
+            Result.failure(mapNetworkException(e))
         } catch (e: ApolloException) {
-            Timber.e(e, "[$operation] API error")
-            Result.failure(DomainError.ApiError.Unknown(e))
+            val cause = e.cause
+            if (cause is NetworkException) {
+                Timber.e(e, "[$operation] Network error (via Apollo)")
+                Result.failure(mapNetworkException(cause))
+            } else {
+                Timber.e(e, "[$operation] API error")
+                Result.failure(DomainError.ApiError.Unknown(e))
+            }
         } catch (e: IOException) {
             Timber.e(e, "[$operation] Network IO error")
             Result.failure(DomainError.NetworkError.NoConnection(e))
@@ -308,5 +318,18 @@ class AnnictRepositoryImpl @Inject constructor(
             Timber.e(e, "[$operation] Unexpected error")
             Result.failure(DomainError.Unknown(cause = e))
         }
+    }
+
+    private fun mapNetworkException(e: NetworkException): DomainError = when (e) {
+        is NetworkException.TimeoutException -> DomainError.NetworkError.Timeout(e)
+        is NetworkException.NoNetworkException -> DomainError.NetworkError.NoConnection(e)
+        is NetworkException.SecurityException -> DomainError.NetworkError.Unknown(e)
+        is NetworkException.UnauthorizedException -> DomainError.AuthError.InvalidToken(e)
+        is NetworkException.ServerErrorException -> DomainError.ApiError.ServerError(e)
+        is NetworkException.ForbiddenException -> DomainError.ApiError.ClientError(e.code, e)
+        is NetworkException.NotFoundException -> DomainError.ApiError.ClientError(e.code, e)
+        is NetworkException.RateLimitException -> DomainError.ApiError.ClientError(e.code, e)
+        is NetworkException.UnknownHttpException -> DomainError.ApiError.ClientError(e.code, e)
+        else -> DomainError.NetworkError.Unknown(e)
     }
 }

--- a/app/src/test/java/com/zelretch/aniiiiict/data/repository/AnnictRepositoryImplTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/data/repository/AnnictRepositoryImplTest.kt
@@ -10,17 +10,21 @@ import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.api.Error
 import com.apollographql.apollo.api.Mutation
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.exception.ApolloNetworkException
 import com.benasher44.uuid.Uuid
 import com.zelretch.aniiiiict.data.api.AnnictApolloClient
 import com.zelretch.aniiiiict.data.auth.AnnictAuthManager
 import com.zelretch.aniiiiict.data.auth.TokenManager
+import com.zelretch.aniiiiict.data.exception.NetworkException
 import com.zelretch.aniiiiict.data.model.Record
+import com.zelretch.aniiiiict.domain.error.DomainError
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -657,6 +661,97 @@ class AnnictRepositoryImplTest {
 
             // Then
             assertTrue(result.isFailure)
+        }
+    }
+
+    @Nested
+    @DisplayName("ネットワークエラーのハンドリング")
+    inner class NetworkErrorHandling {
+
+        @Test
+        @DisplayName("NetworkException.TimeoutExceptionがDomainError.NetworkError.Timeoutにマッピングされる")
+        fun タイムアウト例外がNetworkErrorTimeoutにマッピングされる() = runTest {
+            // Given
+            coEvery { tokenManager.getAccessToken() } returns "token"
+            coEvery {
+                annictApolloClient.executeQuery(any<Query<*>>(), any<String>(), any())
+            } throws NetworkException.TimeoutException("timeout")
+
+            // When
+            val result = repository.getRawProgramsData()
+
+            // Then
+            assertTrue(result.isFailure)
+            assertInstanceOf(DomainError.NetworkError.Timeout::class.java, result.exceptionOrNull())
+        }
+
+        @Test
+        @DisplayName("NetworkException.NoNetworkExceptionがDomainError.NetworkError.NoConnectionにマッピングされる")
+        fun 未接続例外がNetworkErrorNoConnectionにマッピングされる() = runTest {
+            // Given
+            coEvery { tokenManager.getAccessToken() } returns "token"
+            coEvery {
+                annictApolloClient.executeQuery(any<Query<*>>(), any<String>(), any())
+            } throws NetworkException.NoNetworkException("no network")
+
+            // When
+            val result = repository.getRawProgramsData()
+
+            // Then
+            assertTrue(result.isFailure)
+            assertInstanceOf(DomainError.NetworkError.NoConnection::class.java, result.exceptionOrNull())
+        }
+
+        @Test
+        @DisplayName("NetworkException.ServerErrorExceptionがDomainError.ApiError.ServerErrorにマッピングされる")
+        fun サーバーエラー例外がApiErrorServerErrorにマッピングされる() = runTest {
+            // Given
+            coEvery { tokenManager.getAccessToken() } returns "token"
+            coEvery {
+                annictApolloClient.executeQuery(any<Query<*>>(), any<String>(), any())
+            } throws NetworkException.ServerErrorException(500, null, "server error")
+
+            // When
+            val result = repository.getRawProgramsData()
+
+            // Then
+            assertTrue(result.isFailure)
+            assertInstanceOf(DomainError.ApiError.ServerError::class.java, result.exceptionOrNull())
+        }
+
+        @Test
+        @DisplayName("NetworkException.UnauthorizedExceptionがDomainError.AuthError.InvalidTokenにマッピングされる")
+        fun 認証エラー例外がAuthErrorInvalidTokenにマッピングされる() = runTest {
+            // Given
+            coEvery { tokenManager.getAccessToken() } returns "token"
+            coEvery {
+                annictApolloClient.executeQuery(any<Query<*>>(), any<String>(), any())
+            } throws NetworkException.UnauthorizedException(401, null, "unauthorized")
+
+            // When
+            val result = repository.getRawProgramsData()
+
+            // Then
+            assertTrue(result.isFailure)
+            assertInstanceOf(DomainError.AuthError.InvalidToken::class.java, result.exceptionOrNull())
+        }
+
+        @Test
+        @DisplayName("ApolloExceptionの原因がNetworkExceptionの場合適切なDomainErrorにマッピングされる")
+        fun Apollo経由のNetworkExceptionが適切にマッピングされる() = runTest {
+            // Given
+            coEvery { tokenManager.getAccessToken() } returns "token"
+            val networkCause = NetworkException.TimeoutException("timeout")
+            coEvery {
+                annictApolloClient.executeQuery(any<Query<*>>(), any<String>(), any())
+            } throws ApolloNetworkException("apollo network error", networkCause)
+
+            // When
+            val result = repository.getRawProgramsData()
+
+            // Then
+            assertTrue(result.isFailure)
+            assertInstanceOf(DomainError.NetworkError.Timeout::class.java, result.exceptionOrNull())
         }
     }
 }


### PR DESCRIPTION
## Summary
- `NetworkException`は`Exception`を継承していて`IOException`ではないため、`executeApiRequest`の`catch (e: IOException)`にヒットせず、タイムアウト・未接続・HTTP 4xx/5xxエラーがすべて`DomainError.Unknown`（「処理中にエラーが発生しました」）に落ちていた
- `catch (e: NetworkException)`を追加し、各サブクラスを適切な`DomainError`にマッピング
- `ApolloException`の原因が`NetworkException`の場合も同様に処理

## マッピング
| NetworkException | DomainError |
|---|---|
| TimeoutException | NetworkError.Timeout → 「接続がタイムアウトしました」 |
| NoNetworkException | NetworkError.NoConnection → 「ネットワーク接続を確認してください」 |
| SecurityException | NetworkError.Unknown |
| UnauthorizedException | AuthError.InvalidToken → 「認証トークンが無効です」 |
| ServerErrorException | ApiError.ServerError → 「サーバーで問題が発生しています」 |
| HttpException系 | ApiError.ClientError(statusCode) → HTTPコード別メッセージ |

## 変更ファイル
- `AnnictRepositoryImpl`: `mapNetworkException()`ヘルパー追加、`executeApiRequest`のcatch順序更新
- `AnnictRepositoryImplTest`: ネットワークエラーハンドリングのテスト5件追加

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)