### PR TITLE
chore: split UI tests into separate workflow and add permissions

### DIFF
--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -15,6 +15,8 @@ jobs:
   build:
     if: ${{ !(github.event.action == 'opened' && github.event.pull_request.user.login == 'Copilot') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       GRADLE_OPTS: -Dorg.gradle.configuration-cache=false
       ANNICT_CLIENT_ID: ${{ secrets.ANNICT_CLIENT_ID }}

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -15,6 +15,8 @@ jobs:
   test_and_lint:
     if: ${{ !(github.event.action == 'opened' && github.event.pull_request.user.login == 'Copilot') }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       GRADLE_OPTS: -Dorg.gradle.configuration-cache=false
       ANNICT_CLIENT_ID: 'dummy'
@@ -43,17 +45,3 @@ jobs:
 
       - name: Run unit tests
         run: ./gradlew testDebugUnitTest
-
-      - name: Enable KVM
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
-      - name: Run UI tests
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 36
-          target: google_apis
-          arch: x86_64
-          script: ./gradlew connectedDebugAndroidTest

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -1,0 +1,92 @@
+name: UI Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ master ]
+  push:
+    branches: [ master ]
+
+concurrency:
+  group: pr-ui-tests-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  ui_tests:
+    if: ${{ !(github.event.action == 'opened' && github.event.pull_request.user.login == 'Copilot') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      GRADLE_OPTS: -Dorg.gradle.configuration-cache=false
+      ANNICT_CLIENT_ID: 'dummy'
+      ANNICT_CLIENT_SECRET: 'dummy'
+      MAL_CLIENT_ID: 'dummy'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Decode debug keystore
+        run: |
+          mkdir -p app
+          printf '%s' "${{ secrets.DEBUG_KEYSTORE_BASE64 }}" | base64 -d > app/debug.keystore
+
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: AVD cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-36
+
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 36
+          target: google_apis
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
+      - name: Run instrumentation tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 36
+          target: google_apis
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: ./gradlew connectedDebugAndroidTest --stacktrace
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-test-reports
+          path: app/build/reports/androidTests/
+          retention-days: 7


### PR DESCRIPTION
## Summary
- `test-and-lint.yml` から UI テストを分離し、ktlint + detekt + unit tests のみに整理
- `ui-tests.yml` を新規作成（AVD キャッシュ、テストレポートアップロード、permissions: contents: read）
- `build-debug-apk.yml` に `permissions: contents: read` を追加

## Test plan
- [x] unit tests: `./gradlew testDebugUnitTest` パス
- [x] UI tests: `./gradlew connectedDebugAndroidTest` 76テスト全パス (Pixel_9_Pro AVD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)