### PR TITLE
feat: ライブラリに中断（ON_HOLD）を追加 (#245)

### DIFF
--- a/app/src/main/java/com/zelretch/aniiiiict/domain/sync/LibrarySyncService.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/domain/sync/LibrarySyncService.kt
@@ -25,7 +25,7 @@ class LibrarySyncService @Inject constructor(
     private val _status = MutableStateFlow<SyncStatus>(SyncStatus.Idle)
     val status: StateFlow<SyncStatus> = _status.asStateFlow()
 
-    private val targetStates = listOf(StatusState.WANNA_WATCH, StatusState.WATCHING)
+    private val targetStates = listOf(StatusState.WANNA_WATCH, StatusState.WATCHING, StatusState.ON_HOLD)
 
     suspend fun sync() {
         if (_status.value is SyncStatus.Syncing) {

--- a/app/src/main/java/com/zelretch/aniiiiict/ui/common/components/StatusStateExt.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/ui/common/components/StatusStateExt.kt
@@ -7,7 +7,7 @@ fun StatusState.toJapaneseLabel(): String = when (this) {
     StatusState.WANNA_WATCH -> "見たい"
     StatusState.WATCHED -> "見た"
     StatusState.STOP_WATCHING -> "中止"
-    StatusState.ON_HOLD -> "保留"
+    StatusState.ON_HOLD -> "中断"
     StatusState.UNKNOWN__ -> "未設定"
     else -> toString()
 }


### PR DESCRIPTION
## Summary

- `LibrarySyncService.targetStates` に `ON_HOLD` を追加（中断作品もライブラリに表示）
- `ON_HOLD` のラベルを「保留」→「中断」に変更
- `STOP_WATCHING`（中止）は対象外のまま

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)