### PR TITLE
fix: エピソード情報がない作品を「すべて視聴済み」と誤表示しない

### DIFF
--- a/app/src/androidTest/java/com/zelretch/aniiiiict/ui/library/LibraryScreenUITest.kt
+++ b/app/src/androidTest/java/com/zelretch/aniiiiict/ui/library/LibraryScreenUITest.kt
@@ -335,4 +335,36 @@ class LibraryScreenUITest {
         // Assert - インライン展開やモーダルではなく作品詳細へ遷移
         assert(navigatedWorkId == "work1")
     }
+
+    @Test
+    fun libraryScreen_エピソード情報がない作品_すべて視聴済みと表示されない() {
+        // Arrange - 映画等、Annict上にエピソード情報が無く未視聴（見たい）のケース
+        val mockViewModel = mockk<LibraryViewModel>(relaxed = true)
+        val entry = LibraryEntry(
+            id = "entry1",
+            work = Work(
+                id = "work1",
+                title = "テスト映画",
+                viewerStatusState = StatusState.WANNA_WATCH,
+                noEpisodes = true
+            ),
+            nextEpisode = null,
+            statusState = StatusState.WANNA_WATCH
+        )
+        val state = LibraryUiState(entries = listOf(entry), allEntries = listOf(entry))
+        every { mockViewModel.uiState } returns MutableStateFlow(state)
+
+        // Act
+        composeTestRule.setContent {
+            LibraryScreen(
+                viewModel = mockViewModel,
+                uiState = state,
+                onNavigateBack = {}
+            )
+        }
+
+        // Assert - 未視聴なのに「すべて視聴済み」と表示されてはいけない
+        composeTestRule.onNodeWithText("すべて視聴済み").assertDoesNotExist()
+        composeTestRule.onNodeWithText("エピソード情報なし").assertIsDisplayed()
+    }
 }

--- a/app/src/main/java/com/zelretch/aniiiiict/ui/library/LibraryScreen.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/ui/library/LibraryScreen.kt
@@ -449,12 +449,20 @@ private fun LibraryNextEpisodeRow(
     val episode = entry.nextEpisode
     // 視聴済み（WATCHED）作品はボタンなしの静的表示
     val isWatched = entry.statusState == StatusState.WATCHED
+    // 映画等、Annict上にエピソード情報自体が存在しない作品（視聴済みとは別概念）
+    val hasNoEpisodeData = entry.work.noEpisodes
     HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
     Row(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        if (episode == null || isWatched) {
+        if (episode == null && !isWatched && hasNoEpisodeData) {
+            Text(
+                text = "エピソード情報なし",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        } else if (episode == null || isWatched) {
             Icon(
                 imageVector = Icons.Default.Check,
                 contentDescription = null,


### PR DESCRIPTION
## 問題
ライブラリ画面で、映画のようにAnnict上にエピソード情報自体が登録されていない作品は`nextEpisode`が常に`null`になるため、視聴済み(WATCHED)作品と全く同じ「すべて視聴済み」表示になっていた。「見たい」ステータスのまま一度も見ていない映画にも「すべて視聴済み」と出るのはおかしい、との指摘を受けて修正。

## 変更点
- `LibraryEntryCard`/`LibraryNextEpisodeRow`で`work.noEpisodes`を見て、エピソード情報がないだけ（未視聴含む）のケースを「視聴済み」と区別。
- `episode == null && !isWatched && noEpisodes` の場合は「エピソード情報なし」と表示（チェックアイコンなし）。
- `episode == null`だが`noEpisodes`ではない（＝本当に最新話まで見終わった）場合は従来通り「すべて視聴済み」。

## テスト
- UIテスト追加：`libraryScreen_エピソード情報がない作品_すべて視聴済みと表示されない`
- `./gradlew check` green
- `connectedDebugAndroidTest`（library配下）19/19 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)