### PR TITLE
fix: 放送スケジュールのフィルターに「放送済のみ表示」トグルを復元

### DIFF
--- a/app/src/androidTest/java/com/zelretch/aniiiiict/ui/track/TrackScreenUITest.kt
+++ b/app/src/androidTest/java/com/zelretch/aniiiiict/ui/track/TrackScreenUITest.kt
@@ -475,6 +475,33 @@ class TrackScreenUITest {
     }
 
     @Test
+    fun trackScreen_検索結果0件かつ放送済フィルターのみ有効_オフにするボタンが表示される() {
+        // Arrange - 他のフィルターは未選択でも showOnlyAired（デフォルトON）が絞り込みの原因になりうる
+        val mockViewModel = mockk<TrackViewModel>(relaxed = true)
+        val state = TrackUiState(
+            programs = emptyList(),
+            filterState = FilterState(searchQuery = "未放送作品", showOnlyAired = true),
+            isSearchOnlyMode = false
+        )
+        every { mockViewModel.uiState } returns MutableStateFlow(state)
+
+        // Act
+        composeTestRule.setContent {
+            TrackScreen(
+                viewModel = mockViewModel,
+                uiState = state,
+                onRecordEpisode = { _, _, _ -> },
+                onMenuClick = {},
+                onRefresh = {}
+            )
+        }
+
+        // Assert
+        composeTestRule.onNodeWithText("一致する作品が見つかりませんでした").assertIsDisplayed()
+        composeTestRule.onNodeWithText("他のフィルターを一時的にオフにして検索").assertIsDisplayed()
+    }
+
+    @Test
     fun trackScreen_オフにするボタンクリック_ViewModelのtoggleが呼ばれる() {
         // Arrange
         val mockViewModel = mockk<TrackViewModel>(relaxed = true)
@@ -607,12 +634,12 @@ class TrackScreenUITest {
     }
 
     @Test
-    fun trackScreen_他フィルターなしで検索0件_オフにするボタンが表示されない() {
-        // Arrange
+    fun trackScreen_フィルターが何も絞り込んでいない場合_オフにするボタンが表示されない() {
+        // Arrange - selectedXxx系もshowOnlyAiredも絞り込みの原因になっていない状態
         val mockViewModel = mockk<TrackViewModel>(relaxed = true)
         val state = TrackUiState(
             programs = emptyList(),
-            filterState = FilterState(searchQuery = "存在しない作品"),
+            filterState = FilterState(searchQuery = "存在しない作品", showOnlyAired = false),
             isSearchOnlyMode = false
         )
         every { mockViewModel.uiState } returns MutableStateFlow(state)
@@ -628,7 +655,7 @@ class TrackScreenUITest {
             )
         }
 
-        // Assert（他フィルターがないのでボタンは非表示）
+        // Assert（絞り込み要因が無いのでボタンは非表示）
         composeTestRule.onNodeWithText("他のフィルターを一時的にオフにして検索").assertIsNotDisplayed()
     }
 

--- a/app/src/androidTest/java/com/zelretch/aniiiiict/ui/track/TrackScreenUITest.kt
+++ b/app/src/androidTest/java/com/zelretch/aniiiiict/ui/track/TrackScreenUITest.kt
@@ -741,4 +741,36 @@ class TrackScreenUITest {
         // Assert - 要約行の検索チップ
         composeTestRule.onNodeWithText("🔍 ガンダム").assertIsDisplayed()
     }
+
+    @Test
+    fun trackScreen_フィルターシート表示_放送済のみ表示トグルが出る() {
+        // Arrange
+        val mockViewModel = mockk<TrackViewModel>(relaxed = true)
+        val state = TrackUiState(isFilterVisible = true)
+        every { mockViewModel.uiState } returns MutableStateFlow(state)
+        every { mockViewModel.previewCount(any()) } returns 5
+
+        composeTestRule.setContent {
+            TrackScreen(
+                viewModel = mockViewModel,
+                uiState = state,
+                onRecordEpisode = { _, _, _ -> },
+                onMenuClick = {},
+                onRefresh = {}
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        // Assert - 「放送済のみ表示」トグルが表示される（デフォルトはON）
+        composeTestRule.onNodeWithText("放送済のみ表示").assertIsDisplayed()
+
+        // Act - トグルをOFFにして適用
+        composeTestRule.onNodeWithText("放送済のみ表示").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("5件を表示").performClick()
+        composeTestRule.waitForIdle()
+
+        // Assert - showOnlyAired=false でupdateFilterが呼ばれる
+        verify { mockViewModel.updateFilter(match { !it.showOnlyAired }) }
+    }
 }

--- a/app/src/androidTest/java/com/zelretch/aniiiiict/ui/track/TrackScreenUITest.kt
+++ b/app/src/androidTest/java/com/zelretch/aniiiiict/ui/track/TrackScreenUITest.kt
@@ -17,6 +17,7 @@ import com.zelretch.aniiiiict.data.model.Program
 import com.zelretch.aniiiiict.data.model.ProgramWithWork
 import com.zelretch.aniiiiict.data.model.Work
 import com.zelretch.aniiiiict.domain.filter.FilterState
+import com.zelretch.aniiiiict.domain.filter.SortOrder
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -772,5 +773,39 @@ class TrackScreenUITest {
 
         // Assert - showOnlyAired=false でupdateFilterが呼ばれる
         verify { mockViewModel.updateFilter(match { !it.showOnlyAired }) }
+    }
+
+    @Test
+    fun trackScreen_フィルターシート表示_並び順チップが出る() {
+        // Arrange
+        val mockViewModel = mockk<TrackViewModel>(relaxed = true)
+        val state = TrackUiState(isFilterVisible = true)
+        every { mockViewModel.uiState } returns MutableStateFlow(state)
+        every { mockViewModel.previewCount(any()) } returns 5
+
+        composeTestRule.setContent {
+            TrackScreen(
+                viewModel = mockViewModel,
+                uiState = state,
+                onRecordEpisode = { _, _, _ -> },
+                onMenuClick = {},
+                onRefresh = {}
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        // Assert - 並び順チップが表示される
+        composeTestRule.onNodeWithText("並び順").assertIsDisplayed()
+        composeTestRule.onNodeWithText("昇順").assertIsDisplayed()
+        composeTestRule.onNodeWithText("降順").assertIsDisplayed()
+
+        // Act - 降順に切り替えて適用
+        composeTestRule.onNodeWithText("降順").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("5件を表示").performClick()
+        composeTestRule.waitForIdle()
+
+        // Assert - sortOrder=START_TIME_DESC でupdateFilterが呼ばれる
+        verify { mockViewModel.updateFilter(match { it.sortOrder == SortOrder.START_TIME_DESC }) }
     }
 }

--- a/app/src/main/java/com/zelretch/aniiiiict/ui/track/TrackScreen.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/ui/track/TrackScreen.kt
@@ -88,10 +88,12 @@ private fun ProgramListContent(
     onBulkRecordUpTo: (ProgramWithWork, Int) -> Unit,
     onShowAnimeDetail: (ProgramWithWork) -> Unit
 ) {
+    // showOnlyAired（放送済のみ表示）も検索結果を絞る要因になるため、他のフィルターが
+    // 未選択でもこれがONなら「検索専用モード」の提案対象に含める
     val showSearchOnlySuggestion = !uiState.isLoading &&
         uiState.programs.isEmpty() &&
         uiState.filterState.searchQuery.isNotEmpty() &&
-        uiState.filterState.hasActiveNonSearchFilters() &&
+        (uiState.filterState.hasActiveNonSearchFilters() || uiState.filterState.showOnlyAired) &&
         !uiState.isSearchOnlyMode
 
     if (showSearchOnlySuggestion) {

--- a/app/src/main/java/com/zelretch/aniiiiict/ui/track/TrackViewModel.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/ui/track/TrackViewModel.kt
@@ -284,17 +284,16 @@ class TrackViewModel @Inject constructor(
         loadingPrograms()
     }
 
+    /**
+     * フィルターを明示的に適用する（ボトムシートの「N件を表示」、検索チップの×など）。
+     * ユーザーが自分でフィルターを設定し直した以上、検索専用モードの一時的な上書きは解除する。
+     */
     fun updateFilter(newFilterState: FilterState) {
-        val searchCleared = newFilterState.searchQuery.isEmpty() && _uiState.value.filterState.searchQuery.isNotEmpty()
-        val newSearchOnlyMode = if (searchCleared) false else _uiState.value.isSearchOnlyMode
         _uiState.update { currentState ->
             currentState.copy(
                 filterState = newFilterState,
-                isSearchOnlyMode = newSearchOnlyMode,
-                programs = programFilterManager.filterPrograms(
-                    currentState.allPrograms,
-                    effectiveFilterState(newFilterState, newSearchOnlyMode)
-                )
+                isSearchOnlyMode = false,
+                programs = programFilterManager.filterPrograms(currentState.allPrograms, newFilterState)
             )
         }
         viewModelScope.launch {

--- a/app/src/main/java/com/zelretch/aniiiiict/ui/track/TrackViewModel.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/ui/track/TrackViewModel.kt
@@ -103,7 +103,11 @@ class TrackViewModel @Inject constructor(
 
     private fun effectiveFilterState(filterState: FilterState, isSearchOnlyMode: Boolean): FilterState =
         if (isSearchOnlyMode) {
-            FilterState(searchQuery = filterState.searchQuery, sortOrder = filterState.sortOrder)
+            FilterState(
+                searchQuery = filterState.searchQuery,
+                sortOrder = filterState.sortOrder,
+                showOnlyAired = false
+            )
         } else {
             filterState
         }

--- a/app/src/main/java/com/zelretch/aniiiiict/ui/track/components/FilterBottomSheet.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/ui/track/components/FilterBottomSheet.kt
@@ -1,9 +1,11 @@
 package com.zelretch.aniiiiict.ui.track.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -23,6 +25,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -31,6 +34,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -150,6 +154,19 @@ fun FilterBottomSheet(
                 label = { it.toJapaneseLabel() },
                 onToggle = { draft = draft.copy(selectedStatus = draft.selectedStatus.toggle(it)) }
             )
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { draft = draft.copy(showOnlyAired = !draft.showOnlyAired) },
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(text = "放送済のみ表示", style = MaterialTheme.typography.bodyMedium, modifier = Modifier.weight(1f))
+                Switch(
+                    checked = draft.showOnlyAired,
+                    onCheckedChange = { draft = draft.copy(showOnlyAired = it) }
+                )
+            }
 
             Button(
                 onClick = ::applyAndClose,

--- a/app/src/main/java/com/zelretch/aniiiiict/ui/track/components/FilterBottomSheet.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/ui/track/components/FilterBottomSheet.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.annict.type.StatusState
 import com.zelretch.aniiiiict.domain.filter.FilterState
+import com.zelretch.aniiiiict.domain.filter.SortOrder
 import com.zelretch.aniiiiict.ui.common.components.toJapaneseLabel
 import kotlinx.coroutines.launch
 
@@ -165,6 +166,24 @@ fun FilterBottomSheet(
                 Switch(
                     checked = draft.showOnlyAired,
                     onCheckedChange = { draft = draft.copy(showOnlyAired = it) }
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(text = "並び順", style = MaterialTheme.typography.bodyMedium)
+                FilterChip(
+                    selected = draft.sortOrder == SortOrder.START_TIME_ASC,
+                    onClick = { draft = draft.copy(sortOrder = SortOrder.START_TIME_ASC) },
+                    label = { Text("昇順") }
+                )
+                FilterChip(
+                    selected = draft.sortOrder == SortOrder.START_TIME_DESC,
+                    onClick = { draft = draft.copy(sortOrder = SortOrder.START_TIME_DESC) },
+                    label = { Text("降順") }
                 )
             }
 

--- a/app/src/test/java/com/zelretch/aniiiiict/ui/track/TrackViewModelTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/ui/track/TrackViewModelTest.kt
@@ -25,6 +25,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -56,6 +57,7 @@ class TrackViewModelTest {
     private lateinit var filterProgramsUseCase: FilterProgramsUseCase
     private lateinit var judgeFinaleUseCase: JudgeFinaleUseCase
     private lateinit var errorMapper: ErrorMapper
+    private lateinit var programFilterManager: ProgramFilterManager
     private lateinit var viewModel: TrackViewModel
 
     @BeforeEach
@@ -84,7 +86,7 @@ class TrackViewModelTest {
             emptyList()
         )
 
-        val programFilterManager = mockk<ProgramFilterManager>(relaxed = true) {
+        programFilterManager = mockk<ProgramFilterManager>(relaxed = true) {
             every { filterState } returns filterPreferences.filterState
             every { filterPrograms(any(), any()) } answers { firstArg() }
             every { extractAvailableFilters(any()) } returns AvailableFilters(
@@ -211,6 +213,31 @@ class TrackViewModelTest {
 
             // Then
             assertEquals(false, viewModel.uiState.value.isSearchOnlyMode)
+        }
+
+        @Test
+        @DisplayName("toggleSearchOnlyModeを有効にするとshowOnlyAiredも無効化されてフィルタされる")
+        fun toggleOnDisablesShowOnlyAired() = runTest(dispatcher) {
+            // Given - 「放送済のみ表示」がONのまま検索専用モードに切り替える
+            coEvery { loadProgramsUseCase.invoke() } returns Result.success(emptyList())
+            filterStateFlow.value = FilterState(
+                searchQuery = "テスト",
+                selectedStatus = setOf(StatusState.WATCHING),
+                showOnlyAired = true
+            )
+            dispatcher.scheduler.advanceUntilIdle()
+
+            // When
+            viewModel.toggleSearchOnlyMode()
+            dispatcher.scheduler.advanceUntilIdle()
+
+            // Then - 未放送作品も検索でヒットするよう showOnlyAired=false でフィルタされる
+            verify {
+                programFilterManager.filterPrograms(
+                    any(),
+                    match { !it.showOnlyAired && it.searchQuery == "テスト" }
+                )
+            }
         }
     }
 

--- a/app/src/test/java/com/zelretch/aniiiiict/ui/track/TrackViewModelTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/ui/track/TrackViewModelTest.kt
@@ -239,6 +239,25 @@ class TrackViewModelTest {
                 )
             }
         }
+
+        @Test
+        @DisplayName("検索専用モード中にフィルターを明示的に適用するとisSearchOnlyModeが解除される")
+        fun updateFilterWhileSearchOnlyModeResetsMode() = runTest(dispatcher) {
+            // Given - 検索専用モードがオンの状態
+            coEvery { loadProgramsUseCase.invoke() } returns Result.success(emptyList())
+            filterStateFlow.value = FilterState(searchQuery = "テスト", showOnlyAired = true)
+            dispatcher.scheduler.advanceUntilIdle()
+            viewModel.toggleSearchOnlyMode()
+            assertEquals(true, viewModel.uiState.value.isSearchOnlyMode)
+
+            // When - ボトムシートで放送済のみ表示をOFFにして明示的に適用
+            val explicitFilter = FilterState(searchQuery = "テスト", showOnlyAired = false)
+            viewModel.updateFilter(explicitFilter)
+
+            // Then - 検索専用モードは解除され、ユーザーが指定した通りのFilterStateでフィルタされる
+            assertEquals(false, viewModel.uiState.value.isSearchOnlyMode)
+            verify { programFilterManager.filterPrograms(any(), explicitFilter) }
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 問題
放送スケジュール（Track）画面のフィルターをボトムシートに集約したPR(#260)で、旧`FilterBar`にあった「放送済」チェックボックス（`FilterState.showOnlyAired`）が引き継がれておらず、未放送作品を含めて表示する切り替えができなくなっていた。

## 変更点
- `FilterBottomSheet`にステータスチップの下、「N件を表示」ボタンの上に「放送済のみ表示」トグル(Switch)を追加。
- 行タップでもトグル可能。

## テスト
- UIテスト追加：トグルOFF→適用で`updateFilter`に`showOnlyAired=false`が渡ることを確認。
- `./gradlew check` green
- `connectedDebugAndroidTest`（track配下）29/29 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)