### PR TITLE
feat: アニメ詳細画面にキャスト（声優）セクションを追加 (#251)

### DIFF
--- a/app/src/androidTest/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailScreenUITest.kt
+++ b/app/src/androidTest/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailScreenUITest.kt
@@ -251,6 +251,45 @@ class AnimeDetailScreenUITest {
     }
 
     @Test
+    fun キャスト情報がある場合にセクションが表示される() {
+        // Given: キャスト（声優）情報を含むAnimeDetailInfo
+        val mockCharacter = mockk<WorkDetailQuery.Character>()
+        every { mockCharacter.name } returns "テストキャラ"
+        val mockPerson = mockk<WorkDetailQuery.Person>()
+        every { mockPerson.name } returns "テスト声優"
+        val mockCast = mockk<WorkDetailQuery.Node2>()
+        every { mockCast.id } returns "cast-1"
+        every { mockCast.name } returns "テスト声優"
+        every { mockCast.character } returns mockCharacter
+        every { mockCast.person } returns mockPerson
+
+        val animeDetailInfo = createAnimeDetailInfo(
+            casts = listOf(mockCast)
+        )
+        val mockViewModel = createMockViewModel(
+            state = UiState.Success(AnimeDetailData(animeDetailInfo = animeDetailInfo))
+        )
+        val programWithWork = createSampleProgramWithWork()
+
+        // When: 画面を表示
+        composeTestRule.setContent {
+            AniiiiictTheme {
+                AnimeDetailScreen(
+                    workId = "test-work-id",
+                    programWithWork = programWithWork,
+                    onNavigateBack = {},
+                    viewModel = mockViewModel
+                )
+            }
+        }
+
+        // Then: キャストセクションが表示される
+        composeTestRule.onNodeWithText("キャスト").assertIsDisplayed()
+        composeTestRule.onNodeWithText("テストキャラ").assertIsDisplayed()
+        composeTestRule.onNodeWithText("テスト声優").assertIsDisplayed()
+    }
+
+    @Test
     fun 関連作品情報がある場合にセクションが表示される() {
         // Given: 関連作品情報を含むAnimeDetailInfo
         val mockRelatedWork = mockk<WorkSeriesListQuery.Node2>()
@@ -426,7 +465,8 @@ class AnimeDetailScreenUITest {
         wikipediaUrl: String? = null,
         malInfo: MyAnimeListResponse? = null,
         programs: List<WorkDetailQuery.Node1?>? = null,
-        seriesList: List<WorkSeriesListQuery.Node1?>? = null
+        seriesList: List<WorkSeriesListQuery.Node1?>? = null,
+        casts: List<WorkDetailQuery.Node2?>? = null
     ): AnimeDetailInfo {
         val work = Work(
             id = "test-work-id",
@@ -441,6 +481,7 @@ class AnimeDetailScreenUITest {
         return AnimeDetailInfo(
             work = work,
             programs = programs,
+            casts = casts,
             seriesList = seriesList,
             malInfo = malInfo,
             episodeCount = episodeCount,

--- a/app/src/main/graphql/com.annict/WorkDetail.graphql
+++ b/app/src/main/graphql/com.annict/WorkDetail.graphql
@@ -28,6 +28,20 @@ query WorkDetail($workId: ID!) {
           }
         }
       }
+      casts(first: 30) {
+        nodes {
+          id
+          name
+          character {
+            id
+            name
+          }
+          person {
+            id
+            name
+          }
+        }
+      }
 }
   }
 }

--- a/app/src/main/java/com/zelretch/aniiiiict/data/model/AnimeDetailInfo.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/data/model/AnimeDetailInfo.kt
@@ -9,6 +9,7 @@ data class AnimeDetailInfo(
 
     // Annict詳細情報
     val programs: List<WorkDetailQuery.Node1?>? = null,
+    val casts: List<WorkDetailQuery.Node2?>? = null,
     val seriesList: List<WorkSeriesListQuery.Node1?>? = null,
 
     // MyAnimeList情報

--- a/app/src/main/java/com/zelretch/aniiiiict/domain/usecase/GetAnimeDetailUseCase.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/domain/usecase/GetAnimeDetailUseCase.kt
@@ -51,6 +51,7 @@ class GetAnimeDetailUseCase @Inject constructor(
             AnimeDetailInfo(
                 work = work,
                 programs = annictDetail?.onWork?.programs?.nodes,
+                casts = annictDetail?.onWork?.casts?.nodes,
                 seriesList = seriesList,
                 malInfo = malInfo,
                 episodeCount = episodeCount,
@@ -111,6 +112,7 @@ class GetAnimeDetailUseCase @Inject constructor(
             AnimeDetailInfo(
                 work = work,
                 programs = onWork.programs?.nodes,
+                casts = onWork.casts?.nodes,
                 seriesList = seriesList,
                 malInfo = malInfo,
                 episodeCount = episodeCount,

--- a/app/src/main/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailScreen.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailScreen.kt
@@ -163,6 +163,12 @@ private fun AnimeDetailContent(
 
         AnimeDetailBasicInfo(animeDetailInfo = animeDetailInfo)
 
+        animeDetailInfo.casts?.let { casts ->
+            if (casts.isNotEmpty()) {
+                AnimeDetailCasts(casts = casts)
+            }
+        }
+
         AnimeDetailExternalLinks(animeDetailInfo = animeDetailInfo)
 
         animeDetailInfo.programs?.let { programs ->
@@ -416,6 +422,48 @@ private fun AnimeDetailPrograms(programs: List<WorkDetailQuery.Node1?>, modifier
                     Text(
                         text = channelName,
                         style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AnimeDetailCasts(casts: List<WorkDetailQuery.Node2?>, modifier: Modifier = Modifier) {
+    // 同一声優・同一キャラの重複を排除し、登場順（sortNumber順のAPI応答順）を維持
+    val uniqueCasts = casts.filterNotNull().distinctBy { it.id }
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(defaultElevation = CARD_ELEVATION.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = "キャスト",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+
+            uniqueCasts.forEach { cast ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = cast.character.name.ifBlank { "―" },
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Text(
+                        text = cast.person.name,
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.weight(1f),
+                        textAlign = androidx.compose.ui.text.style.TextAlign.End
                     )
                 }
             }

--- a/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/GetAnimeDetailUseCaseTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/GetAnimeDetailUseCaseTest.kt
@@ -75,6 +75,9 @@ class GetAnimeDetailUseCaseTest {
             assertNotNull(animeDetailInfo?.programs)
             assertNotNull(animeDetailInfo?.seriesList)
             assertNotNull(animeDetailInfo?.malInfo)
+            // キャスト（声優）情報が取得できている
+            assertEquals("テストキャラ", animeDetailInfo?.casts?.first()?.character?.name)
+            assertEquals("テスト声優", animeDetailInfo?.casts?.first()?.person?.name)
 
             coVerify { annictRepository.getWorkDetail(programWithWork.work.id) }
             coVerify { myAnimeListRepository.getAnimeDetail(12345) }
@@ -183,6 +186,7 @@ class GetAnimeDetailUseCaseTest {
             every { mockOnWork.officialSiteUrl } returns null
             every { mockOnWork.wikipediaUrl } returns null
             every { mockOnWork.programs } returns mockk { every { nodes } returns emptyList() }
+            every { mockOnWork.casts } returns null
 
             val mockNode = mockk<WorkDetailQuery.Node>()
             every { mockNode.onWork } returns mockOnWork
@@ -249,6 +253,7 @@ class GetAnimeDetailUseCaseTest {
             every { mockOnWork.officialSiteUrl } returns "https://example.com/official"
             every { mockOnWork.wikipediaUrl } returns "https://ja.wikipedia.org/wiki/test"
             every { mockOnWork.programs } returns mockk { every { nodes } returns emptyList() }
+            every { mockOnWork.casts } returns null
 
             val mockNode = mockk<WorkDetailQuery.Node>()
             every { mockNode.onWork } returns mockOnWork
@@ -428,6 +433,19 @@ class GetAnimeDetailUseCaseTest {
         every { mockPrograms.nodes } returns listOf(mockProgram)
         every { mockOnWork.programs } returns mockPrograms
 
+        val mockCharacter = mockk<WorkDetailQuery.Character>()
+        every { mockCharacter.name } returns "テストキャラ"
+        val mockPerson = mockk<WorkDetailQuery.Person>()
+        every { mockPerson.name } returns "テスト声優"
+        val mockCast = mockk<WorkDetailQuery.Node2>()
+        every { mockCast.id } returns "cast-id"
+        every { mockCast.name } returns "テスト声優"
+        every { mockCast.character } returns mockCharacter
+        every { mockCast.person } returns mockPerson
+        val mockCasts = mockk<WorkDetailQuery.Casts>()
+        every { mockCasts.nodes } returns listOf(mockCast)
+        every { mockOnWork.casts } returns mockCasts
+
         val mockNode = mockk<WorkDetailQuery.Node>()
         every { mockNode.onWork } returns mockOnWork
 
@@ -484,6 +502,7 @@ class GetAnimeDetailUseCaseTest {
         every { mockOnWork.image } returns mockImage
 
         every { mockOnWork.programs } returns mockk { every { nodes } returns emptyList() }
+        every { mockOnWork.casts } returns null
 
         val mockNode = mockk<WorkDetailQuery.Node>()
         every { mockNode.onWork } returns mockOnWork


### PR DESCRIPTION
## 概要
アニメ詳細画面に「キャスト（声優）」セクションを追加します。closes #251

## 変更点
- `WorkDetail.graphql` に `casts(first: 30) { character { name } person { name } }` を追加
- `AnimeDetailInfo` / `GetAnimeDetailUseCase` でキャストを受け渡し
- `AnimeDetailScreen` に「キャスト」カードを追加（基本情報の下）。役名（左・淡色）→ 声優名（右）で表示、重複は `id` で排除
- `GetAnimeDetailUseCaseTest`（キャスト取得の検証）と `AnimeDetailScreenUITest`（キャストセクション表示）を追加

## 動作確認
- エミュレータ（API33）実機で「キングダム 第3シリーズ」を確認 → 蒙恬/野島裕史、嬴政/福山潤、河了貂/釘宮理恵 等が正しく表示（`Work.casts` は HTTP 200）
- `./gradlew ktlintFormat && ./gradlew check` 成功
- `connectedDebugAndroidTest`（AnimeDetailScreenUITest）11件パス

## スクリーンショット
（キングダム 第3シリーズのキャスト一覧が縦に並び、左に役名・右に声優名）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
