### PR TITLE
fix: 作品詳細の関連作品が表示されない不具合を修正 (#254)

### DIFF
--- a/app/src/androidTest/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailScreenUITest.kt
+++ b/app/src/androidTest/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailScreenUITest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.annict.WorkDetailQuery
 import com.annict.WorkSeriesListQuery
+import com.annict.type.Media
 import com.annict.type.SeasonName
 import com.annict.type.StatusState
 import com.zelretch.aniiiiict.data.model.AnimeDetailInfo
@@ -317,8 +318,9 @@ class AnimeDetailScreenUITest {
         // Then: 関連作品セクションが表示される
         composeTestRule.onNodeWithText("関連作品").assertIsDisplayed()
         composeTestRule.onNodeWithText("テストシリーズ").assertIsDisplayed()
-        // 関連作品は "  • タイトル" の形式で表示される
-        composeTestRule.onNodeWithText("  • 関連作品タイトル").assertIsDisplayed()
+        composeTestRule.onNodeWithText("関連作品タイトル").assertIsDisplayed()
+        // メディア種別バッジ（TV）が表示される
+        composeTestRule.onNodeWithText("TV").assertIsDisplayed()
     }
 
     @Test
@@ -345,7 +347,7 @@ class AnimeDetailScreenUITest {
                 )
             }
         }
-        composeTestRule.onNodeWithText("  • 関連作品タイトル").performClick()
+        composeTestRule.onNodeWithText("関連作品タイトル").performClick()
 
         // Then: 関連作品IDでナビゲーションが呼ばれる
         assert(navigatedWorkId == "related-work-id")
@@ -400,6 +402,7 @@ class AnimeDetailScreenUITest {
         val mockItem = mockk<WorkSeriesListQuery.Item>()
         every { mockItem.id } returns workId
         every { mockItem.title } returns workTitle
+        every { mockItem.media } returns Media.TV
         every { mockItem.seasonName } returns null
         every { mockItem.seasonYear } returns null
         every { mockItem.image } returns null

--- a/app/src/androidTest/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailScreenUITest.kt
+++ b/app/src/androidTest/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailScreenUITest.kt
@@ -292,22 +292,7 @@ class AnimeDetailScreenUITest {
     @Test
     fun 関連作品情報がある場合にセクションが表示される() {
         // Given: 関連作品情報を含むAnimeDetailInfo
-        val mockRelatedWork = mockk<WorkSeriesListQuery.Node2>()
-        every { mockRelatedWork.id } returns "work-1"
-        every { mockRelatedWork.title } returns "関連作品タイトル"
-        every { mockRelatedWork.titleEn } returns null
-        every { mockRelatedWork.seasonName } returns null
-        every { mockRelatedWork.seasonYear } returns null
-        every { mockRelatedWork.image } returns null
-
-        val mockWorks = mockk<WorkSeriesListQuery.Works>()
-        every { mockWorks.nodes } returns listOf(mockRelatedWork)
-
-        val mockSeries = mockk<WorkSeriesListQuery.Node1>()
-        every { mockSeries.id } returns "series-1"
-        every { mockSeries.name } returns "テストシリーズ"
-        every { mockSeries.nameEn } returns "Test Series"
-        every { mockSeries.works } returns mockWorks
+        val mockSeries = mockSeriesNode(workId = "work-1", workTitle = "関連作品タイトル")
 
         val animeDetailInfo = createAnimeDetailInfo(
             seriesList = listOf(mockSeries)
@@ -339,22 +324,7 @@ class AnimeDetailScreenUITest {
     @Test
     fun 関連作品をタップすると遷移コールバックが呼ばれる() {
         // Given: 関連作品情報を含むAnimeDetailInfo
-        val mockRelatedWork = mockk<WorkSeriesListQuery.Node2>()
-        every { mockRelatedWork.id } returns "related-work-id"
-        every { mockRelatedWork.title } returns "関連作品タイトル"
-        every { mockRelatedWork.titleEn } returns null
-        every { mockRelatedWork.seasonName } returns null
-        every { mockRelatedWork.seasonYear } returns null
-        every { mockRelatedWork.image } returns null
-
-        val mockWorks = mockk<WorkSeriesListQuery.Works>()
-        every { mockWorks.nodes } returns listOf(mockRelatedWork)
-
-        val mockSeries = mockk<WorkSeriesListQuery.Node1>()
-        every { mockSeries.id } returns "series-1"
-        every { mockSeries.name } returns "テストシリーズ"
-        every { mockSeries.nameEn } returns ""
-        every { mockSeries.works } returns mockWorks
+        val mockSeries = mockSeriesNode(workId = "related-work-id", workTitle = "関連作品タイトル")
 
         val animeDetailInfo = createAnimeDetailInfo(seriesList = listOf(mockSeries))
         val mockViewModel = createMockViewModel(
@@ -424,6 +394,28 @@ class AnimeDetailScreenUITest {
             coEvery { loadAnimeDetailById(any()) } returns Unit
             coEvery { changeStatus(any()) } returns Unit
         }
+
+    // Annict の Series.works は edges { item } 経由で取得するため、その構造でモックする
+    private fun mockSeriesNode(workId: String, workTitle: String): WorkSeriesListQuery.Node1 {
+        val mockItem = mockk<WorkSeriesListQuery.Item>()
+        every { mockItem.id } returns workId
+        every { mockItem.title } returns workTitle
+        every { mockItem.seasonName } returns null
+        every { mockItem.seasonYear } returns null
+        every { mockItem.image } returns null
+
+        val mockEdge = mockk<WorkSeriesListQuery.Edge>()
+        every { mockEdge.item } returns mockItem
+
+        val mockWorks = mockk<WorkSeriesListQuery.Works>()
+        every { mockWorks.edges } returns listOf(mockEdge)
+
+        val mockSeries = mockk<WorkSeriesListQuery.Node1>()
+        every { mockSeries.id } returns "series-1"
+        every { mockSeries.name } returns "テストシリーズ"
+        every { mockSeries.works } returns mockWorks
+        return mockSeries
+    }
 
     private fun createSampleProgramWithWork(): ProgramWithWork {
         val work = Work(

--- a/app/src/main/graphql/com.annict/WorkSeriesList.graphql
+++ b/app/src/main/graphql/com.annict/WorkSeriesList.graphql
@@ -5,16 +5,18 @@ query WorkSeriesList($workId: ID!) {
         nodes {
           id
           name
-          nameEn
-          works(first: 10) {
-            nodes {
-              id
-              title
-              titleEn
-              seasonName
-              seasonYear
-              image {
-                recommendedImageUrl
+          # NOTE: Annict の Series.works は nodes で辿ると HTTP 500 になるため、
+          # edges { item } 経由で取得する必要がある。
+          works(first: 30, orderBy: { field: SEASON, direction: ASC }) {
+            edges {
+              item {
+                id
+                title
+                seasonName
+                seasonYear
+                image {
+                  recommendedImageUrl
+                }
               }
             }
           }

--- a/app/src/main/graphql/com.annict/WorkSeriesList.graphql
+++ b/app/src/main/graphql/com.annict/WorkSeriesList.graphql
@@ -12,6 +12,7 @@ query WorkSeriesList($workId: ID!) {
               item {
                 id
                 title
+                media
                 seasonName
                 seasonYear
                 image {

--- a/app/src/main/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailScreen.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailScreen.kt
@@ -1,6 +1,7 @@
 package com.zelretch.aniiiiict.ui.animedetail
 
 import android.content.Intent
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -49,6 +51,7 @@ import androidx.core.net.toUri
 import coil.compose.AsyncImage
 import com.annict.WorkDetailQuery
 import com.annict.WorkSeriesListQuery
+import com.annict.type.Media
 import com.annict.type.StatusState
 import com.zelretch.aniiiiict.data.model.AnimeDetailInfo
 import com.zelretch.aniiiiict.data.model.ProgramWithWork
@@ -58,6 +61,7 @@ import com.zelretch.aniiiiict.ui.common.components.toStatusColor
 
 private const val IMAGE_SIZE = 120
 private const val CARD_ELEVATION = 2
+private const val MEDIA_BADGE_RADIUS = 4
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -522,11 +526,12 @@ private fun AnimeDetailRelatedWorks(
                                 .fillMaxWidth()
                                 .clickable { onNavigateToWork(work.id) }
                                 .padding(vertical = 4.dp),
-                            horizontalArrangement = Arrangement.SpaceBetween,
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
+                            MediaBadge(media = work.media)
                             Text(
-                                text = "  • ${work.title}",
+                                text = work.title,
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.primary,
                                 modifier = Modifier.weight(1f),
@@ -545,6 +550,30 @@ private fun AnimeDetailRelatedWorks(
             }
         }
     }
+}
+
+/** 関連作品のメディア種別（映画/TV/OVA/WEB/その他）を表す小さなバッジ。 */
+@Composable
+private fun MediaBadge(media: Media, modifier: Modifier = Modifier) {
+    val label = when (media) {
+        Media.MOVIE -> "映画"
+        Media.TV -> "TV"
+        Media.OVA -> "OVA"
+        Media.WEB -> "WEB"
+        Media.OTHER, Media.UNKNOWN__ -> "その他"
+    }
+    Text(
+        text = label,
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSecondaryContainer,
+        maxLines = 1,
+        modifier = modifier
+            .background(
+                color = MaterialTheme.colorScheme.secondaryContainer,
+                shape = RoundedCornerShape(MEDIA_BADGE_RADIUS.dp)
+            )
+            .padding(horizontal = 6.dp, vertical = 1.dp)
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailScreen.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailScreen.kt
@@ -179,7 +179,11 @@ private fun AnimeDetailContent(
 
         animeDetailInfo.seriesList?.let { seriesList ->
             if (seriesList.isNotEmpty()) {
-                AnimeDetailRelatedWorks(seriesList = seriesList, onNavigateToWork = onNavigateToWork)
+                AnimeDetailRelatedWorks(
+                    seriesList = seriesList,
+                    currentWorkId = animeDetailInfo.work.id,
+                    onNavigateToWork = onNavigateToWork
+                )
             }
         }
     }
@@ -474,9 +478,20 @@ private fun AnimeDetailCasts(casts: List<WorkDetailQuery.Node2?>, modifier: Modi
 @Composable
 private fun AnimeDetailRelatedWorks(
     seriesList: List<WorkSeriesListQuery.Node1?>,
+    currentWorkId: String,
     onNavigateToWork: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    // シリーズごとに、表示中の作品を除外した作品リストを構築（並び順はクエリの orderBy: SEASON に従う）
+    val seriesWithWorks = seriesList.filterNotNull().map { series ->
+        val works = series.works?.edges?.mapNotNull { it?.item }
+            ?.filter { it.id != currentWorkId }
+            .orEmpty()
+        series to works
+    }.filter { it.second.isNotEmpty() }
+
+    if (seriesWithWorks.isEmpty()) return
+
     Card(
         modifier = modifier.fillMaxWidth(),
         elevation = CardDefaults.cardElevation(defaultElevation = CARD_ELEVATION.dp)
@@ -491,7 +506,7 @@ private fun AnimeDetailRelatedWorks(
                 fontWeight = FontWeight.Bold
             )
 
-            seriesList.filterNotNull().forEach { series ->
+            seriesWithWorks.forEach { (series, works) ->
                 Column(
                     verticalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
@@ -501,7 +516,7 @@ private fun AnimeDetailRelatedWorks(
                         fontWeight = FontWeight.Medium
                     )
 
-                    series.works?.nodes?.filterNotNull()?.forEach { work ->
+                    works.forEach { work ->
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()

--- a/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/GetAnimeDetailUseCaseTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/domain/usecase/GetAnimeDetailUseCaseTest.kt
@@ -453,21 +453,23 @@ class GetAnimeDetailUseCaseTest {
     }
 
     private fun createMockWorkSeriesListNode(): WorkSeriesListQuery.Node {
-        val mockWork = mockk<WorkSeriesListQuery.Node2>()
-        every { mockWork.id } returns "related-work-id"
-        every { mockWork.title } returns "関連作品"
-        every { mockWork.titleEn } returns "Related Work"
-        every { mockWork.seasonName } returns null
-        every { mockWork.seasonYear } returns null
-        every { mockWork.image } returns null
+        // Annict の Series.works は edges { item } 経由で取得する
+        val mockItem = mockk<WorkSeriesListQuery.Item>()
+        every { mockItem.id } returns "related-work-id"
+        every { mockItem.title } returns "関連作品"
+        every { mockItem.seasonName } returns null
+        every { mockItem.seasonYear } returns null
+        every { mockItem.image } returns null
+
+        val mockEdge = mockk<WorkSeriesListQuery.Edge>()
+        every { mockEdge.item } returns mockItem
 
         val mockWorks = mockk<WorkSeriesListQuery.Works>()
-        every { mockWorks.nodes } returns listOf(mockWork)
+        every { mockWorks.edges } returns listOf(mockEdge)
 
         val mockSeries = mockk<WorkSeriesListQuery.Node1>()
         every { mockSeries.id } returns "series-id"
         every { mockSeries.name } returns "テストシリーズ"
-        every { mockSeries.nameEn } returns "Test Series"
         every { mockSeries.works } returns mockWorks
 
         val mockSeriesList = mockk<WorkSeriesListQuery.SeriesList>()


### PR DESCRIPTION
## 概要
作品詳細画面の「関連作品」セクションが常に空だった不具合を修正します。closes #254

## 原因
Annict公開GraphQLの `Series.works` は `nodes` で辿ると **HTTP 500** を返す（サーバ側リゾルバの不具合）。そのため `seriesList { nodes { works { nodes {...} } } }` が失敗し、関連作品が一切表示されていなかった（エラーは握り潰されていた）。

## 修正
`works` を **`edges { item }` 経由**で取得すると 200 で正しく取れることが判明したため、クエリを変更。

- `WorkSeriesList.graphql`: `works(orderBy: { field: SEASON, direction: ASC }) { edges { item { id title seasonName seasonYear image } } }`
  - `edges { item }` で 500 を回避
  - `orderBy: SEASON` でシーズン昇順に整列（サーバ側）
- `AnimeDetailScreen`: 表示中の作品を関連作品から除外し、作品が空になったシリーズは非表示
- UI/UseCase テストのモックを edges/item 構造に更新

## 動作確認
- エミュレータ（API33）実機で「キングダム 第3シリーズ」→ 第1/2/4/5/6シリーズ・続編が**シーズン順**で表示（第3シリーズ=表示中は除外）、タップで各詳細へ遷移できることを確認
- `Series.works` の各取得方法を実測比較: `nodes`→500 / `nodes{annictId}`→200だが別作品のidが返る（不正） / **`edges{item}`→200・正しいデータ**
- `./gradlew ktlintFormat && ./gradlew check` 成功
- `connectedDebugAndroidTest`（AnimeDetailScreenUITest）10件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
