### PR TITLE
feat: 詳細画面でステータス変更後、閉じる時に遷移元へ反映する (#256)

### DIFF
--- a/app/src/main/java/com/zelretch/aniiiiict/MainActivity.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/MainActivity.kt
@@ -3,6 +3,7 @@ package com.zelretch.aniiiiict
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.foundation.Image
@@ -57,7 +58,9 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.zelretch.aniiiiict.domain.sync.SyncStatus
 import com.zelretch.aniiiiict.ui.animedetail.AnimeDetailScreen
+import com.zelretch.aniiiiict.ui.animedetail.AnimeDetailViewModel
 import com.zelretch.aniiiiict.ui.auth.AuthScreen
+import com.zelretch.aniiiiict.ui.base.UiState
 import com.zelretch.aniiiiict.ui.history.HistoryScreen
 import com.zelretch.aniiiiict.ui.history.HistoryScreenActions
 import com.zelretch.aniiiiict.ui.history.HistoryViewModel
@@ -319,16 +322,35 @@ private fun AppNavigation(mainViewModel: MainViewModel) {
                 val trackBackStackEntry = remember(backStackEntry) {
                     runCatching { navController.getBackStackEntry("track") }.getOrNull()
                 }
+                val libraryBackStackEntry = remember(backStackEntry) {
+                    runCatching { navController.getBackStackEntry("library") }.getOrNull()
+                }
                 val trackViewModel: TrackViewModel? = trackBackStackEntry?.let { hiltViewModel(it) }
+                val libraryViewModel: LibraryViewModel? = libraryBackStackEntry?.let { hiltViewModel(it) }
+                val detailViewModel: AnimeDetailViewModel = hiltViewModel()
                 val programWithWork = trackViewModel?.getProgramWithWork(workId)
+
+                // 画面を閉じる際、この画面でステータス変更していれば遷移元へ反映する
+                val onClose: () -> Unit = {
+                    val changed = (detailViewModel.uiState.value as? UiState.Success)?.data?.statusChanged == true
+                    if (changed) {
+                        trackViewModel?.refresh()
+                        libraryViewModel?.onWorkStatusChanged(workId)
+                    }
+                    navController.navigateUp()
+                }
+
+                // システムバック（ジェスチャー/戻るボタン）でも反映されるようにする
+                BackHandler(onBack = onClose)
 
                 AnimeDetailScreen(
                     workId = workId,
                     programWithWork = programWithWork,
-                    onNavigateBack = { navController.navigateUp() },
+                    onNavigateBack = onClose,
                     onNavigateToWork = { relatedWorkId ->
                         navController.navigate("anime_detail/$relatedWorkId")
-                    }
+                    },
+                    viewModel = detailViewModel
                 )
             }
             composable("settings") {

--- a/app/src/main/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailViewModel.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailViewModel.kt
@@ -25,7 +25,9 @@ data class AnimeDetailData(
     val animeDetailInfo: AnimeDetailInfo,
     val selectedStatus: StatusState? = null,
     val isStatusChanging: Boolean = false,
-    val statusChangeError: String? = null
+    val statusChangeError: String? = null,
+    // この画面でステータス変更が成功したか（閉じる時に遷移元へ反映するために使う）
+    val statusChanged: Boolean = false
 )
 
 /**
@@ -127,7 +129,7 @@ class AnimeDetailViewModel @Inject constructor(
                     return@launch
                 }
             (_uiState.value as? UiState.Success)?.data?.let { data ->
-                _uiState.value = UiState.Success(data.copy(isStatusChanging = false))
+                _uiState.value = UiState.Success(data.copy(isStatusChanging = false, statusChanged = true))
             }
         }
     }

--- a/app/src/main/java/com/zelretch/aniiiiict/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/zelretch/aniiiiict/ui/library/LibraryViewModel.kt
@@ -127,6 +127,15 @@ class LibraryViewModel @Inject constructor(
     }
 
     /**
+     * 詳細画面などで作品のステータスが変更されたとき、workId から該当エントリーを引いて再同期する。
+     * ライブラリに存在しない作品（該当エントリー無し）の場合は何もしない。
+     */
+    fun onWorkStatusChanged(workId: String) {
+        val entryId = _uiState.value.allEntries.firstOrNull { it.work.id == workId }?.id ?: return
+        onEntryUpdated(entryId)
+    }
+
+    /**
      * カードの「見た」ボタン：次の1話をその場で記録し、ライブラリを再同期して進捗に反映する。
      */
     fun recordNextEpisode(entry: LibraryEntry) {

--- a/app/src/test/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailViewModelTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/ui/animedetail/AnimeDetailViewModelTest.kt
@@ -185,6 +185,8 @@ class AnimeDetailViewModelTest {
             val state = viewModel.uiState.value
             assertTrue(state is UiState.Success)
             assertEquals(StatusState.WATCHED, (state as UiState.Success).data.selectedStatus)
+            // 遷移元へ反映するためのフラグが立つ
+            assertTrue(state.data.statusChanged)
         }
 
         @Test
@@ -208,6 +210,8 @@ class AnimeDetailViewModelTest {
             assertTrue(state is UiState.Success)
             assertEquals(StatusState.WATCHING, (state as UiState.Success).data.selectedStatus)
             assertEquals("ステータス変更に失敗しました", state.data.statusChangeError)
+            // 失敗時はフラグを立てない（遷移元を無駄にリフレッシュしない）
+            assertEquals(false, state.data.statusChanged)
         }
     }
 

--- a/app/src/test/java/com/zelretch/aniiiiict/ui/library/LibraryViewModelTest.kt
+++ b/app/src/test/java/com/zelretch/aniiiiict/ui/library/LibraryViewModelTest.kt
@@ -429,6 +429,52 @@ class LibraryViewModelTest {
         }
 
         @Test
+        @DisplayName("onWorkStatusChangedでworkIdから該当エントリーを再同期する")
+        fun onWorkStatusChangedSyncsMatchingEntry() = runTest(dispatcher) {
+            // Given
+            val entry = LibraryEntry(
+                id = "entry1",
+                work = createFakeWork("work1", "Work 1"),
+                nextEpisode = null,
+                statusState = StatusState.WATCHING
+            )
+            coEvery { loadLibraryEntriesUseCase() } returns Result.success(listOf(entry))
+            coEvery { librarySyncService.syncEntry(any()) } returns Unit
+
+            val viewModel = createViewModel()
+            viewModel.uiState.first { !it.isLoading }
+
+            // When: 詳細画面で work1 のステータスが変更された
+            viewModel.onWorkStatusChanged("work1")
+
+            // Then: workId から entry1 を引いて再同期する
+            coVerify { librarySyncService.syncEntry("entry1") }
+        }
+
+        @Test
+        @DisplayName("onWorkStatusChangedで該当エントリーが無ければ何もしない")
+        fun onWorkStatusChangedNoopWhenNotFound() = runTest(dispatcher) {
+            // Given
+            val entry = LibraryEntry(
+                id = "entry1",
+                work = createFakeWork("work1", "Work 1"),
+                nextEpisode = null,
+                statusState = StatusState.WATCHING
+            )
+            coEvery { loadLibraryEntriesUseCase() } returns Result.success(listOf(entry))
+            coEvery { librarySyncService.syncEntry(any()) } returns Unit
+
+            val viewModel = createViewModel()
+            viewModel.uiState.first { !it.isLoading }
+
+            // When: ライブラリに存在しない作品
+            viewModel.onWorkStatusChanged("unknown-work")
+
+            // Then: 再同期は呼ばれない
+            coVerify(exactly = 0) { librarySyncService.syncEntry(any()) }
+        }
+
+        @Test
         @DisplayName("recordNextEpisodeで次の話が記録され再同期される")
         fun recordNextEpisodeRecordsAndSyncs() = runTest(dispatcher) {
             // Given


### PR DESCRIPTION
## 概要
作品詳細画面でステータスを変更しても、閉じたときに遷移元（Track/放送スケジュール, Library）へ反映されなかった問題を修正します。closes #256

## 変更点
- `AnimeDetailData` に `statusChanged` フラグを追加。`changeStatus` 成功時に立てる（失敗時は立てない）
- `LibraryViewModel.onWorkStatusChanged(workId)` を追加。workId から該当エントリーを引いて既存の `onEntryUpdated`（syncEntry + Room再読込）で再同期
- `MainActivity`: 詳細画面を閉じる際、この画面でステータス変更していれば
  - 共有している `TrackViewModel.refresh()`（API再読込で反映）
  - `LibraryViewModel.onWorkStatusChanged(workId)`（該当エントリーを再同期）
  を呼ぶ。戻るボタンに加え **`BackHandler` でシステムバック（ジェスチャー/戻るキー）も捕捉**
- 関連作品の入れ子遷移でも、共有VM参照経由なので最終的に反映される
- ViewModel のユニットテストを追加

## 動作確認
- エミュレータ実機で「キングダム 第3シリーズ」のステータスを 見たい→見てる に変更→システムバック→Trackのラベルが「見てる」に更新されることを確認（逆方向も確認）
- `./gradlew ktlintFormat && ./gradlew check` 成功
- `connectedDebugAndroidTest` 全82件パス（既存挙動の非破壊を確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
